### PR TITLE
docs: Add Cursor agent

### DIFF
--- a/features/agents.mdx
+++ b/features/agents.mdx
@@ -13,6 +13,7 @@ Tembo supports agents to solve your software engineering tasks. Each agent has d
 | **Codex**       | OpenAI           | `gpt-5-medium`      |
 | **Opencode**    | Anthropic/OpenAI | `claude-4-5-sonnet` |
 | **Amp**         | Anthropic        | `claude-4-5-sonnet` |
+| **Cursor**      | Anthropic/OpenAI | `gpt-5-medium`      |
 
 ### Claude Code (Default)
 
@@ -53,6 +54,17 @@ Amp is a powerful AI coding agent powered by Anthropic's Claude models.
 
 Amp uses smart model detection and currently uses [Sonnet 4.5](https://ampcode.com/news/claude-sonnet-4-5) as its main model.
 
+### Cursor
+
+Cursor is an AI coding agent supporting both Anthropic Claude models and OpenAI GPT models through the Cursor CLI.
+
+**Supported Models:**
+
+- `claude-4-5-sonnet` - Balanced performance and cost
+- `claude-4.1-opus` - Maximum capability for complex tasks
+- `gpt-5` - Powerful reasoning and code generation
+- `composer-1` - OpenAI's composer model
+
 ## Selecting an Agent
 
 Agents are specified using an agent key format: `agentType:model`
@@ -63,6 +75,7 @@ Agents are specified using an agent key format: `agentType:model`
 - `codex:gpt-5-medium`
 - `opencode:claude-4-5-sonnet`
 - `amp:claude-4-5-sonnet`
+- `cursor:gpt-5`
 
 If no agent is specified, Tembo defaults to `claudeCode:claude-4-5-sonnet`.
 


### PR DESCRIPTION
## Description
Add the Cursor agent to the `agents.mdx` documentation, including its supported models.

## Changes
Added Cursor to the agents table and a new section detailing its supported models (`claude-4-5-sonnet`, `claude-4.1-opus`, `gpt-5`, `composer-1`). Updated agent selection examples. 
  


 <br /> 


 > Want me to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=1)](https://app.tembo.io/tasks/d8bd8459-a95d-4b63-aa9c-12d34114bf5b) [![slack.com](https://internal.tembo.io/static/view/slack.svg)](https://tembo-io.slack.com/archives/C08S9PXF1KJ/p1761941607100709)