### PR TITLE
Move integration links

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -33,9 +33,6 @@
           {
             "group": "Onboarding Tembo",
             "pages": [
-              "integrations/github",
-              "integrations/gitlab",
-              "integrations/bitbucket",
               "features/rule-files",
               "inviting-your-team"
             ]
@@ -54,6 +51,9 @@
           {
             "group": "Integrations",
             "pages": [
+              "integrations/github",
+              "integrations/gitlab",
+              "integrations/bitbucket",
               "integrations/slack",
               "integrations/sentry",
               "integrations/linear",


### PR DESCRIPTION
## Description
Moved GitLab, GitHub, and Bitbucket links to the 'Integrations' section in the sidebar.
## Changes
Relocated `integrations/github`, `integrations/gitlab`, `integrations/bitbucket` entries in `docs.json`. 
  


 <br /> 


 > Want me to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=1)](https://app.tembo.io/tasks/47e8068b-fe42-4f94-ba97-c8bb02633b13) 