### PR TITLE
Update integration icons

### DIFF
--- a/integrations/aws.mdx
+++ b/integrations/aws.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'AWS RDS'
-icon: '/images/aws.svg'
+icon: 'aws'
 ---
 
 Connect AWS RDS PostgreSQL instances to Tembo for performance monitoring and optimization.

--- a/integrations/jira.mdx
+++ b/integrations/jira.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Jira"
-icon: "/images/jira.svg"
+icon: "jira"
 ---
 
 Assign Jira tickets to Tembo and turn them into PRs.

--- a/integrations/linear.mdx
+++ b/integrations/linear.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Linear'
-icon: '/images/linear.svg'
+icon: 'linear'
 ---
 
 Assign Linear issues to Tembo and turn them into PRs.

--- a/integrations/postgres.mdx
+++ b/integrations/postgres.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Postgres'
-icon: '/images/postgres.svg'
+icon: 'postgres'
 ---
 
 Connect PostgreSQL databases to Tembo for performance monitoring and optimization.

--- a/integrations/sentry.mdx
+++ b/integrations/sentry.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sentry"
-icon: "/images/sentry.svg"
+icon: "sentry"
 ---
 
 Connect Sentry to Tembo for automatic error detection and code fixes. When Sentry detects an error in your application, Tembo analyzes the stack trace and creates a pull request with a targeted fix.


### PR DESCRIPTION
## Description
Use default Mintlify icons for Sentry, Linear, AWS, Postgres, Jira.
## Changes
Removed `/images/` and `.svg` from icon paths. 
  


 <br /> 


 > Want me to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=1)](https://app.tembo.io/tasks/0ef77e84-42e1-41e7-acfb-eff072f9d572) 