### PR TITLE
Fix: Invalid origin error

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -130,6 +130,10 @@
 		{
 			"source": "/ai-agent/tembo-md",
 			"destination": "/features/rule-files"
+		},
+		{
+			"source": "/docs/getting-started/postgres_guides/:slug*",
+			"destination": "/integrations/postgres"
 		}
 	]
 }


### PR DESCRIPTION
## Description
Fixes an "invalid origin" JS error at `/docs/getting-started/postgres_guides/how-to-load-census-data-with-ogr2ogr`.
## Changes
Added a redirect in `docs.json` from `/docs/getting-started/postgres_guides/:slug*` to `/integrations/postgres`.
 
  


 <br /> 


 > Want me to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=1)](https://app.tembo.io/tasks/2aaff00c-89e3-4b66-b6e4-33ee9e5672ba) [![sentry.io](https://internal.tembo.io/static/view/sentry.svg)](https://tembo-io.sentry.io/issues/7003319277/)