### PR TITLE
Fix Mintlify dark mode

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -13,6 +13,10 @@
 			"dark": "#080808"
 		}
 	},
+	"appearance": {
+		"default": "system",
+		"strict": false
+	},
 	"favicon": "/favicon.ico",
 	"api": {
 		"openapi": "/openapi.documented.yml"


### PR DESCRIPTION
## Description
Mintlify docs render in light mode despite system dark mode.
## Changes
Added `appearance` config to `docs.json` to set default to `system`. 
  


 <br /> 


 > Want me to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=1)](https://app.tembo.io/tasks/47ef315c-11ea-42a9-affb-f055456e83e6)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/opencode:claude-opus-4-5?v=1)](https://app.tembo.io/settings/agents)