### PR TITLE
Docs: Add Kernel MCP

### DIFF
--- a/features/mcp-servers.mdx
+++ b/features/mcp-servers.mdx
@@ -21,6 +21,7 @@ Tembo provides several MCP servers out of the box:
 | **Tembo**    | `stdio` | Core Tembo tools (sub-issues, Slack, tasks) |
 | **Playwright** | `stdio` | Browser automation and web testing         |
 | **Context7** | `stdio` | Context management and search              |
+| **Kernel**   | `http`  | Cloud browser infrastructure and automation |
 
 ### Tembo MCP
 
@@ -42,6 +43,30 @@ Enables agents to automate browser interactions:
 ### Context7 MCP
 
 Provides enhanced context management capabilities for your agents.
+
+### Kernel MCP
+
+The [Kernel](https://onkernel.com) MCP server provides cloud-based browser infrastructure for AI agents and automation tasks. It offers serverless browsers with anti-bot detection, session persistence, and autoscaling capabilities.
+
+**Key use cases:**
+
+- **Web scraping and data extraction** - Extract data from websites that require JavaScript rendering or authentication
+- **Automated testing** - Run end-to-end browser tests in isolated cloud environments
+- **Form filling and submissions** - Automate complex web workflows that require user interactions
+- **Screenshot capture** - Generate screenshots of web pages for documentation or monitoring
+- **Browser automation at scale** - Run hundreds of concurrent browser sessions without infrastructure management
+
+**Available tools:**
+
+- **create_browser** / **delete_browser** - Launch and terminate browser sessions
+- **execute_playwright_code** - Run Playwright/TypeScript code with automatic video replay
+- **take_screenshot** - Capture screenshots with optional region selection
+- **setup_profile** / **list_profiles** - Manage browser profiles for session persistence
+- **list_apps** / **invoke_action** - Interact with Kernel apps and deployments
+
+**Configuration:**
+
+To use Kernel MCP, add your Kernel API key in **Settings** > **Agents** under the "Kernel API Key" field. Get your API key from [onkernel.com](https://onkernel.com).
 
 ## Integration MCP Servers
 


### PR DESCRIPTION
## Summary
- Added `Kernel` to the MCP servers table with `http` type.
- Documented the Kernel MCP server, including its purpose, key use cases, available tools, and configuration instructions.
- Highlighted use cases like web scraping, automated testing, and browser automation at scale. 
  


 <br /> 


 > Want me to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=4)](https://app.tembo.io/tasks/c7741f1c-cd49-4dbe-ad86-8dbe71047eb5)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?v=1)](https://app.tembo.io/settings/agents)