### PR TITLE
Add search_docs tool

### DIFF
--- a/features/mcp-servers.mdx
+++ b/features/mcp-servers.mdx
@@ -63,6 +63,7 @@ The [Kernel](https://onkernel.com) MCP server provides cloud-based browser infra
 - **take_screenshot** - Capture screenshots with optional region selection
 - **setup_profile** / **list_profiles** - Manage browser profiles for session persistence
 - **list_apps** / **invoke_action** - Interact with Kernel apps and deployments
+- **search_docs** - Search Kernel documentation for up-to-date information via MCP query
 
 **Configuration:**
 


### PR DESCRIPTION
## Summary
Added the `search_docs` tool to the Kernel MCP server features documentation. This tool allows searching Kernel documentation for up-to-date information via MCP query. 
  


 <br /> 


 > Want me to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=4)](https://app.tembo.io/tasks/e31eb57c-e2ce-45ae-b274-4c1416c12649) [![slack.com](https://internal.tembo.io/static/view/slack.svg?v=4)](https://tembo-io.slack.com/archives/C094UFXHKKP/p1765220756517489) [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?v=1)](https://app.tembo.io/settings/agents)