### PR TITLE
Remove LinkedIn link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -172,7 +172,6 @@
             "x": "https://x.com/tembo",
             "github": "https://github.com/tembo",
             "discord": "https://discord.gg/anPdgArb",
-            "linkedin": "https://www.linkedin.com/company/tembo-inc/",
             "youtube": "https://www.youtube.com/@tembo_io"
         }
     },


### PR DESCRIPTION
## Summary
Removed LinkedIn social media link from the docs configuration file. The LinkedIn URL reference has been deleted from the social links section in `docs.json`. 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/1167df26-af1a-4095-87fe-779dbffea9f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.3-codex?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.3-codex?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.3-codex?theme=light&v=11" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C094UFXHKKP/p1775571505464569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>