### PR TITLE
Rewrite skills documentation

### DIFF
--- a/features/agent-skills.mdx
+++ b/features/agent-skills.mdx
@@ -1,54 +1,91 @@
 ---
 title: 'Agent Skills'
-description: 'Guide how agents approach tasks with custom skills in your repository.'
+description: 'Add organization-wide instructions and reference files that Tembo injects into every agent run.'
 ---
 
-Skills are instructions that live in your repository and guide how agents approach work. They help agents follow multi-step processes like research, planning, implementation, and review instead of doing everything in a single pass.
+Skills are custom instructions plus optional extra files that belong to your Tembo organization. When a [coding agent](/features/coding-agents) runs a task, Tembo places your skills into the sandbox workspace so the agent can follow them alongside your [rule files](/features/rule-files) and the task prompt.
 
-## How it works
+Each skill has a name, a short description, and one or more files. The description tells agents when the skill applies. The main instructions live in a required file named `SKILL.md`. You can attach additional files (templates, examples, snippets) that sit next to `SKILL.md` in the same logical folder.
 
-Place skills in the dotfile directory for your coding agent at the root of your repository:
+## Where to manage skills
 
-- `.claude/` for Claude Code
-- `.codex/` for Codex
-- `.opencode/` for OpenCode
-- `.cursor/` for Cursor
+Open the Tembo dashboard, go to **Settings**, open the **Agent** section, and choose **Skills**.
 
-The agent picks up these skills when working on tasks in that repo. You need to instruct the agent to use a skill, either in the task description or after a PR is opened via the [feedback loop](/features/feedback-loop):
+From there you can:
 
-```
-@tembo Use the implementation skill for this task
-```
+- **Add a skill** with **Add skill**. Enter a name, a description, and the file contents. The editor always includes `SKILL.md`; use the plus control to add more files and give each a filename (for example `migration_template.sql`).
+- **Edit or delete** a skill from the table row actions. Saving an edit replaces the entire file set when you submit the form with files included, so include every file you want to keep.
 
-```
-@tembo Now use the code-review skill to review your changes
-```
+Below your organization's skills, the **skills marketplace** lists popular packages from [skills.sh](https://skills.sh). Search requires at least three characters. Use **Install** to copy a marketplace skill into your organization. Tembo downloads the package, maps paths to filenames, and creates a skill for you. If the package defines a `description` in YAML frontmatter in `SKILL.md`, Tembo uses it; otherwise it fills a default description. You can open **View** on a card to see the listing on skills.sh. Installed marketplace skills behave like skills you wrote yourself and you can edit them afterward.
 
-## Example
+## How Tembo applies skills
 
-A skill that guides the agent through a structured implementation flow:
+Skills are **organization scoped**. Every skill you define is available for **every** automated task in that organization: new work, follow ups, and [feedback loop](/features/feedback-loop) iterations. Tembo loads all skills for the org on each run. There is no per automation or per repository toggle inside the product today.
+
+Tembo writes skills into the cloned repository **after** it prepares the agent environment. You do **not** commit these paths to your Git repo yourself; Tembo creates them for that run. The layout depends on which agent runs the task.
+
+### Agents that use a skill directory
+
+These agents get one folder per skill under a fixed path. The folder name is derived from the skill **name**: lowercase letters and numbers with other characters turned into hyphens (for example `Database Migrations` becomes `database-migrations`).
+
+| Agent | Location of each skill | Entry file |
+| ----- | ---------------------- | ---------- |
+| Codex | `.codex/skills/<folder>/` | `SKILL.md` |
+| Cursor | `.cursor/rules/<folder>/` | `SKILL.mdc` |
+
+For **Cursor**, Tembo builds the `.mdc` file with YAML frontmatter: your skill **description**, and `alwaysApply: true`, so the rule loads for the session. Companion files are written beside that file with the names you configured.
+
+### Agents that append to a rule file
+
+These agents do not use a separate skill directory in the sandbox. Tembo **appends** each skill to the agent's main rule file for that run:
+
+| Agent | Rule file updated |
+| ----- | ----------------- |
+| Claude Code | `CLAUDE.md` |
+| OpenCode, Amp, Pi | `AGENTS.md` |
+
+For each skill, Tembo adds a heading with the skill name, a short quoted line with the description, the full `SKILL.md` body, then each companion file as its own subsection with the file content inside a fenced code block.
+
+If a skill is missing `SKILL.md`, Tembo skips that skill for the run (you should always keep `SKILL.md` present).
+
+## Authoring `SKILL.md`
+
+Write plain Markdown. Focus on steps, constraints, and checklists the agent should follow. You can use frontmatter in `SKILL.md` if you like for your own structure; Tembo does not require it for custom skills (marketplace installs may already include frontmatter from the upstream package).
+
+**Description field:** Use it to summarize intent in one line (for example "Use when changing the payments API"). Agents that support selective loading can use this to decide whether to read the full skill. Cursor always applies the rule file Tembo generates, and the description is also copied into that file's frontmatter.
+
+**Companion files:** Use them for SQL templates, config samples, or long reference text so `SKILL.md` stays readable. Keep filenames unique within the skill.
+
+## How skills relate to rule files and prompts
+
+- **[Rule files](/features/rule-files)** live in the repository and describe project conventions. Tembo reads them as baseline context.
+- **Skills** live in Tembo and are injected as files or appended sections as described above.
+- **Task text** (issue body, Slack message, or an [`@tembo`](/features/feedback-loop) comment) still steers a single run. Skills are always present for the agent; you can use the task to emphasize one workflow when several skills could apply.
+
+Together, rule files set stable project norms while skills add reusable playbooks your whole org shares.
+
+## Example `SKILL.md`
 
 ```markdown
-# Implementation Skill
+# Database migration workflow
 
-1. Research the codebase to understand existing patterns
-2. Create a plan with specific files and changes
-3. Implement the plan following project conventions
-4. Run tests and fix any failures
-5. Self-review the diff before opening a PR
+When changing the schema:
+
+1. Locate existing migrations and match naming and folder layout.
+2. Write a reversible migration when the database supports it.
+3. Run the project's migration and test commands before opening a PR.
+4. Call out any manual steps for operators in the PR description.
+
+## Checklist
+
+- [ ] Migration file added in the correct directory
+- [ ] Tests or smoke steps documented
+- [ ] Rollback notes included if needed
 ```
 
-## What skills are good for
+## Summary
 
-- Enforcing a research-then-implement workflow
-- Requiring test coverage before opening a PR
-- Defining code review checklists the agent runs against its own output
-- Setting quality thresholds for different task types
-
-## What's coming
-
-We're building first-party skill support and planning mode so Tembo can handle work in staged steps:
-
-**Research → Plan → Implement → Review → Iterate**
-
-This will improve PR quality on larger tasks, where today the agent may need a few iterations before the output is merge-ready. [Rule files](/features/rule-files) and skills in dotfile directories are the best way to guide agents today.
+- Skills are **organization level** instructions with a required `SKILL.md` and optional extra files.
+- Manage them under **Settings → Agent → Skills**; install from the **skills.sh** marketplace on the same page.
+- Tembo injects **all** org skills on **every** agent run, using either per agent skill folders (Codex, Cursor) or appends (Claude Code, OpenCode, Amp, Pi).
+- Write clear **descriptions** so agents know when a skill applies, and keep **companion files** for templates or long references.

--- a/features/agent-skills.mdx
+++ b/features/agent-skills.mdx
@@ -1,13 +1,28 @@
 ---
 title: 'Agent Skills'
-description: 'Add organization-wide instructions and reference files that Tembo injects into every agent run.'
+description: 'Use skills from your repository dot directories, managed organization skills in Tembo, or both.'
 ---
 
-Skills are custom instructions plus optional extra files that belong to your Tembo organization. When a [coding agent](/features/coding-agents) runs a task, Tembo places your skills into the sandbox workspace so the agent can follow them alongside your [rule files](/features/rule-files) and the task prompt.
+Tembo supports skills in two complementary ways:
 
-Each skill has a name, a short description, and one or more files. The description tells agents when the skill applies. The main instructions live in a required file named `SKILL.md`. You can attach additional files (templates, examples, snippets) that sit next to `SKILL.md` in the same logical folder.
+1. **Skills in the repository:** Commit them under your [coding agent](/features/coding-agents) vendor folders at the repo root (dot directories). They are normal project files. When Tembo clones the repository for a task, those paths are already on disk and the agent can use them like any other local checkout.
 
-## Where to manage skills
+2. **Managed skills in Tembo:** Define organization skills in the dashboard under **Settings**, **Agent**, **Skills**. Tembo injects these during the run (see [How Tembo applies managed skills](#how-tembo-applies-managed-skills)). They do not need to live in Git, and the same set applies across repos for your organization.
+
+You can use either approach or both together alongside your [rule files](/features/rule-files) and the task prompt.
+
+## Skills in your repository
+
+Place skills where your agent expects them, usually under a dot directory at the repository root. Exact layout follows each tool. Common examples:
+
+- **Codex:** `.codex/skills/` with a folder per skill and a `SKILL.md` entry (see OpenAI Codex docs for the full convention).
+- **Cursor:** `.cursor/rules/` for rule and skill style files (often `.mdc` with frontmatter).
+
+Other agents may rely more on a single rules file (for example `CLAUDE.md` or `AGENTS.md`) or paths documented by that product. Committing skills in the repo keeps them versioned with the code and reviewable in pull requests.
+
+## Managed skills in Tembo
+
+Each managed skill has a name, a short description, and one or more files. The description tells agents when the skill applies. The main instructions live in a required file named `SKILL.md`. You can attach additional files (templates, examples, snippets) that sit next to `SKILL.md` in the same logical folder.
 
 Open the Tembo dashboard, go to **Settings**, open the **Agent** section, and choose **Skills**.
 
@@ -18,11 +33,13 @@ From there you can:
 
 Below your organization's skills, the **skills marketplace** lists popular packages from [skills.sh](https://skills.sh). Search requires at least three characters. Use **Install** to copy a marketplace skill into your organization. Tembo downloads the package, maps paths to filenames, and creates a skill for you. If the package defines a `description` in YAML frontmatter in `SKILL.md`, Tembo uses it; otherwise it fills a default description. You can open **View** on a card to see the listing on skills.sh. Installed marketplace skills behave like skills you wrote yourself and you can edit them afterward.
 
-## How Tembo applies skills
+## How Tembo applies managed skills
 
-Skills are **organization scoped**. Every skill you define is available for **every** automated task in that organization: new work, follow ups, and [feedback loop](/features/feedback-loop) iterations. Tembo loads all skills for the org on each run. There is no per automation or per repository toggle inside the product today.
+This section applies to skills you configure under **Settings**, **Agent**, **Skills**, not to skill files you committed in the repository before the run.
 
-Tembo writes skills into the cloned repository **after** it prepares the agent environment. You do **not** commit these paths to your Git repo yourself; Tembo creates them for that run. The layout depends on which agent runs the task.
+Managed skills are **organization scoped**. Every managed skill is available for **every** automated task in that organization: new work, follow ups, and [feedback loop](/features/feedback-loop) iterations. Tembo loads all of them on each run. There is no per automation or per repository toggle inside the product today.
+
+Tembo writes managed skills into the cloned repository **after** it prepares the agent environment. You do **not** commit these paths to your Git repo yourself; Tembo creates them for that run. The layout depends on which agent runs the task.
 
 ### Agents that use a skill directory
 
@@ -50,7 +67,9 @@ If a skill is missing `SKILL.md`, Tembo skips that skill for the run (you should
 
 ## Authoring `SKILL.md`
 
-Write plain Markdown. Focus on steps, constraints, and checklists the agent should follow. You can use frontmatter in `SKILL.md` if you like for your own structure; Tembo does not require it for custom skills (marketplace installs may already include frontmatter from the upstream package).
+The following guidance applies to **managed** skills and marketplace installs. Repository skills follow the same filename ideas in many setups, but always match your agent's published layout.
+
+Write plain Markdown. Focus on steps, constraints, and checklists the agent should follow. You can use frontmatter in `SKILL.md` if you like for your own structure; Tembo does not require it for skills you create in the dashboard (marketplace installs may already include frontmatter from the upstream package).
 
 **Description field:** Use it to summarize intent in one line (for example "Use when changing the payments API"). Agents that support selective loading can use this to decide whether to read the full skill. Cursor always applies the rule file Tembo generates, and the description is also copied into that file's frontmatter.
 
@@ -59,10 +78,11 @@ Write plain Markdown. Focus on steps, constraints, and checklists the agent shou
 ## How skills relate to rule files and prompts
 
 - **[Rule files](/features/rule-files)** live in the repository and describe project conventions. Tembo reads them as baseline context.
-- **Skills** live in Tembo and are injected as files or appended sections as described above.
-- **Task text** (issue body, Slack message, or an [`@tembo`](/features/feedback-loop) comment) still steers a single run. Skills are always present for the agent; you can use the task to emphasize one workflow when several skills could apply.
+- **Repository skills** in dot directories ship with the clone and follow each agent's normal discovery rules.
+- **Managed skills** live in Tembo and are injected as files or appended sections as described in [How Tembo applies managed skills](#how-tembo-applies-managed-skills).
+- **Task text** (issue body, Slack message, or an [`@tembo`](/features/feedback-loop) comment) still steers a single run. Managed skills are always present for the agent when configured; you can use the task to emphasize one workflow when several skills could apply.
 
-Together, rule files set stable project norms while skills add reusable playbooks your whole org shares.
+Together, rule files set stable project norms, repository skills stay versioned with the codebase, and managed skills add reusable playbooks your whole org shares.
 
 ## Example `SKILL.md`
 
@@ -85,7 +105,7 @@ When changing the schema:
 
 ## Summary
 
-- Skills are **organization level** instructions with a required `SKILL.md` and optional extra files.
-- Manage them under **Settings → Agent → Skills**; install from the **skills.sh** marketplace on the same page.
-- Tembo injects **all** org skills on **every** agent run, using either per agent skill folders (Codex, Cursor) or appends (Claude Code, OpenCode, Amp, Pi).
-- Write clear **descriptions** so agents know when a skill applies, and keep **companion files** for templates or long references.
+- You can keep skills in **repository dot directories** (for example `.codex/skills/` or `.cursor/rules/`) so they are versioned with the project, and you can add **managed skills** under **Settings**, **Agent**, **Skills** in the Tembo dashboard.
+- Managed skills use a required `SKILL.md` plus optional companion files; install more from the **skills.sh** marketplace on the same page.
+- Tembo injects **all** managed org skills on **every** agent run, using either per agent skill folders (Codex, Cursor) or appends (Claude Code, OpenCode, Amp, Pi).
+- Write clear **descriptions** on managed skills so agents know when a skill applies, and keep **companion files** for templates or long references.

--- a/features/agent-skills.mdx
+++ b/features/agent-skills.mdx
@@ -31,7 +31,7 @@ From there you can:
 - **Add a skill** with **Add skill**. Enter a name, a description, and the file contents. The editor always includes `SKILL.md`; use the plus control to add more files and give each a filename (for example `migration_template.sql`).
 - **Edit or delete** a skill from the table row actions. Saving an edit replaces the entire file set when you submit the form with files included, so include every file you want to keep.
 
-Below your organization's skills, the **skills marketplace** lists popular packages from [skills.sh](https://skills.sh). Search requires at least three characters. Use **Install** to copy a marketplace skill into your organization. Tembo downloads the package, maps paths to filenames, and creates a skill for you. If the package defines a `description` in YAML frontmatter in `SKILL.md`, Tembo uses it; otherwise it fills a default description. You can open **View** on a card to see the listing on skills.sh. Installed marketplace skills behave like skills you wrote yourself and you can edit them afterward.
+Below your organization's skills, the **skills marketplace** connects to [skills.sh](https://skills.sh). Tembo supports **any** skill published there: the page shows popular skills by default, and you can find the rest with search (at least three characters). Use **Install** to copy a marketplace skill into your organization. Tembo downloads the package, maps paths to filenames, and creates a skill for you. If the package defines a `description` in YAML frontmatter in `SKILL.md`, Tembo uses it; otherwise it fills a default description. You can open **View** on a card to see the listing on skills.sh. Installed marketplace skills behave like skills you wrote yourself and you can edit them afterward.
 
 ## How Tembo applies managed skills
 
@@ -106,6 +106,6 @@ When changing the schema:
 ## Summary
 
 - You can keep skills in **repository dot directories** (for example `.codex/skills/` or `.cursor/rules/`) so they are versioned with the project, and you can add **managed skills** under **Settings**, **Agent**, **Skills** in the Tembo dashboard.
-- Managed skills use a required `SKILL.md` plus optional companion files; install more from the **skills.sh** marketplace on the same page.
+- Managed skills use a required `SKILL.md` plus optional companion files; install more from the **skills.sh** marketplace on the same page (any skill on skills.sh, not only the popular list).
 - Tembo injects **all** managed org skills on **every** agent run, using either per agent skill folders (Codex, Cursor) or appends (Claude Code, OpenCode, Amp, Pi).
 - Write clear **descriptions** on managed skills so agents know when a skill applies, and keep **companion files** for templates or long references.


### PR DESCRIPTION
## Summary

Completely rewrote the Agent Skills documentation to reflect the current product implementation. The docs now cover:

- **What skills are**: Organization-scoped custom instructions plus optional files injected into every agent run
- **Where to manage them**: Tembo dashboard Settings > Agent > Skills section
- **How to create and edit**: UI form with `SKILL.md` (required) and companion files
- **Skills marketplace**: Integration with skills.sh for discovering and installing popular packages
- **How Tembo applies skills**: Different injection methods per agent type (skill folders for Codex/Cursor, appends for Claude Code/OpenCode/Amp/Pi)
- **Authoring guidance**: Best practices for `SKILL.md` content, descriptions, and companion files
- **Relationship to rule files and prompts**: Clarified how skills work alongside repository rule files and task text

Removed outdated content about dotfile directories and manual skill invocation. Added comprehensive tables showing agent-specific skill locations and entry files. 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/9c0f597d-444d-4bac-a055-145f53f32e82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/cursor:composer-2-fast?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/cursor:composer-2-fast?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/cursor:composer-2-fast?theme=light&v=11" height="28"></picture></a> 