### PR TITLE
Add header image to self-hosted doc

### DIFF
--- a/features/self-hosted.mdx
+++ b/features/self-hosted.mdx
@@ -3,6 +3,10 @@ title: 'Self-Hosted'
 description: 'Run Tembo inside infrastructure you control, with packaged releases and enterprise support from Tembo.'
 ---
 
+<Frame>
+  <img src="https://apistack-imagebucket97210811-xlmtt1hzvfap.s3.us-east-1.amazonaws.com/org_2vyf1JaTCZ9gS9mILqGFsPyTA6s/b4fb5cfb-0866-48c9-bf7b-5e1c6702f046.png" alt="Self-hosted deployment architecture" />
+</Frame>
+
 Tembo offers a self-hosted deployment for teams that need Tembo to run inside infrastructure they control.
 
 With self-hosted, Tembo runs in your environment instead of Tembo-managed infrastructure. Tembo provides the packaged release, upgrade path, and support, and you decide how it is deployed, networked, and operated.


### PR DESCRIPTION
## Summary
Added header image to the self-hosted documentation page at the top of the document, consistent with integration documentation styling. The image is wrapped in a `<Frame>` component and displays the self-hosted deployment architecture diagram.

**Changes:**
- Inserted image URL in a `<Frame>` component after the frontmatter
- Image placed before the introductory content
- Maintains consistency with existing integration documentation layout 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/b38578e4-19c8-4512-ada6-ccec6824f1c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.4?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.4?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.4?theme=light&v=11" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C08S9PXF1KJ/p1776811141573799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>