### PR TITLE
Add self-hosted overview image

### DIFF
--- a/features/self-hosted.mdx
+++ b/features/self-hosted.mdx
@@ -3,6 +3,10 @@ title: 'Self-Hosted'
 description: 'Run Tembo inside infrastructure you control, with packaged releases and enterprise support from Tembo.'
 ---
 
+<Frame>
+  <img src="/images/self-hosted.png" alt="Tembo self-hosted overview" />
+</Frame>
+
 Tembo offers a self-hosted deployment for teams that need Tembo to run inside infrastructure they control.
 
 With self-hosted, Tembo runs in your environment instead of Tembo-managed infrastructure. Tembo provides the packaged release, upgrade path, and support, and you decide how it is deployed, networked, and operated.


### PR DESCRIPTION
## Summary
Added self-hosted overview image to the top of the self-hosted documentation page. The image is displayed using a `<Frame>` component, matching the pattern used for integration documentation.

**Changes:**
- Added `self-hosted.png` image asset to `/images` directory
- Inserted image with `<Frame>` wrapper at the top of `features/self-hosted.mdx` for visual consistency with other integration docs 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/3f20330b-001f-408f-b1dc-d0751f96e476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.4?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.4?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.4?theme=light&v=11" height="28"></picture></a> 