### PR TITLE
Add cloud provider logos

### DIFF
--- a/features/self-hosted.mdx
+++ b/features/self-hosted.mdx
@@ -11,7 +11,53 @@ Tembo offers a self-hosted deployment for teams that need Tembo to run inside in
 
 With self-hosted, Tembo runs in your environment instead of Tembo-managed infrastructure. Tembo provides the packaged release, upgrade path, and support, and you decide how it is deployed, networked, and operated.
 
-Tembo self-hosted works across **AWS**, **Azure**, and **GCP**.
+Tembo self-hosted works across{' '}
+<span className="cloud-provider cloud-provider-aws">
+  <svg aria-hidden="true" viewBox="0 0 304 182">
+    <path fill="currentColor" d="m86 66 2 9c0 3 1 5 3 8v2l-1 3-7 4-2 1-3-1-4-5-3-6c-8 9-18 14-29 14-9 0-16-3-20-8-5-4-8-11-8-19s3-15 9-20c6-6 14-8 25-8a79 79 0 0 1 22 3v-7c0-8-2-13-5-16-3-4-8-5-16-5l-11 1a80 80 0 0 0-14 5h-2c-1 0-2-1-2-3v-5l1-3c0-1 1-2 3-2l12-5 16-2c12 0 20 3 26 8 5 6 8 14 8 25v32zM46 82l10-2c4-1 7-4 10-7l3-6 1-9v-4a84 84 0 0 0-19-2c-6 0-11 1-15 4-3 2-4 6-4 11s1 8 3 11c3 2 6 4 11 4zm80 10-4-1-2-3-23-78-1-4 2-2h10l4 1 2 4 17 66 15-66 2-4 4-1h8l4 1 2 4 16 67 17-67 2-4 4-1h9c2 0 3 1 3 2v2l-1 2-24 78-2 4-4 1h-9l-4-1-1-4-16-65-15 64-2 4-4 1h-9zm129 3a66 66 0 0 1-27-6l-3-3-1-2v-5c0-2 1-3 2-3h2l3 1a54 54 0 0 0 23 5c6 0 11-2 14-4 4-2 5-5 5-9l-2-7-10-5-15-5c-7-2-13-6-16-10a24 24 0 0 1 5-34l10-5a44 44 0 0 1 20-2 110 110 0 0 1 12 3l4 2 3 2 1 4v4c0 3-1 4-2 4l-4-2c-6-2-12-3-19-3-6 0-11 0-14 2s-4 5-4 9c0 3 1 5 3 7s5 4 11 6l14 4c7 3 12 6 15 10s5 9 5 14l-3 12-7 8c-3 3-7 5-11 6l-14 2z"/>
+    <path fill="#f90" d="M274 144A220 220 0 0 1 4 124c-4-3-1-6 2-4a300 300 0 0 0 263 16c5-2 10 4 5 8z"/>
+    <path fill="#f90" d="M287 128c-4-5-28-3-38-1-4 0-4-3-1-5 19-13 50-9 53-5 4 5-1 36-18 51-3 2-6 1-5-2 5-10 13-33 9-38z"/>
+  </svg>
+  <strong>AWS</strong>
+</span>
+,
+<span className="cloud-provider">
+  <svg aria-hidden="true" viewBox="0 0 96 96">
+    <defs>
+      <linearGradient id="self-hosted-azure-a" x1="-1032.17" x2="-1059.21" y1="145.31" y2="65.43" gradientTransform="matrix(1 0 0 -1 1075 158)" gradientUnits="userSpaceOnUse">
+        <stop offset="0" stopColor="#114a8b" />
+        <stop offset="1" stopColor="#0669bc" />
+      </linearGradient>
+      <linearGradient id="self-hosted-azure-b" x1="-1023.73" x2="-1029.98" y1="108.08" y2="105.97" gradientTransform="matrix(1 0 0 -1 1075 158)" gradientUnits="userSpaceOnUse">
+        <stop offset="0" stopOpacity=".3" />
+        <stop offset=".07" stopOpacity=".2" />
+        <stop offset=".32" stopOpacity=".1" />
+        <stop offset=".62" stopOpacity=".05" />
+        <stop offset="1" stopOpacity="0" />
+      </linearGradient>
+      <linearGradient id="self-hosted-azure-c" x1="-1027.16" x2="-997.48" y1="147.64" y2="68.56" gradientTransform="matrix(1 0 0 -1 1075 158)" gradientUnits="userSpaceOnUse">
+        <stop offset="0" stopColor="#3ccbf4" />
+        <stop offset="1" stopColor="#2892df" />
+      </linearGradient>
+    </defs>
+    <path fill="url(#self-hosted-azure-a)" d="M33.34 6.54h26.04l-27.03 80.1a4.15 4.15 0 0 1-3.94 2.81H8.15a4.14 4.14 0 0 1-3.93-5.47L29.4 9.38a4.15 4.15 0 0 1 3.94-2.83z"/>
+    <path fill="#0078d4" d="M71.17 60.26H29.88a1.91 1.91 0 0 0-1.3 3.31l26.53 24.76a4.17 4.17 0 0 0 2.85 1.13h23.38z"/>
+    <path fill="url(#self-hosted-azure-b)" d="M33.34 6.54a4.12 4.12 0 0 0-3.95 2.88L4.25 83.92a4.14 4.14 0 0 0 3.91 5.54h20.79a4.44 4.44 0 0 0 3.4-2.9l5.02-14.78 17.91 16.7a4.24 4.24 0 0 0 2.67.97h23.29L71.02 60.26H41.24L59.47 6.55z"/>
+    <path fill="url(#self-hosted-azure-c)" d="M66.6 9.36a4.14 4.14 0 0 0-3.93-2.82H33.65a4.15 4.15 0 0 1 3.93 2.82l25.18 74.62a4.15 4.15 0 0 1-3.93 5.48h29.02a4.15 4.15 0 0 0 3.93-5.48z"/>
+  </svg>
+  <strong>Azure</strong>
+</span>
+, and{' '}
+<span className="cloud-provider">
+  <svg aria-hidden="true" viewBox="0 -25 256 256">
+    <path fill="#EA4335" d="m170.252 56.819 22.253-22.253 1.483-9.37C153.437-11.677 88.976-7.496 52.42 33.92 42.267 45.423 34.734 59.764 30.717 74.573l7.97-1.123 44.505-7.34 3.436-3.513c19.797-21.742 53.27-24.667 76.128-6.168l7.496.39Z"/>
+    <path fill="#4285F4" d="M224.205 73.918a100.249 100.249 0 0 0-30.217-48.722l-31.232 31.232a55.515 55.515 0 0 1 20.379 44.037v5.544c15.35 0 27.797 12.445 27.797 27.796 0 15.352-12.446 27.485-27.797 27.485h-55.671l-5.466 5.934v33.34l5.466 5.231h55.67c39.93.311 72.553-31.494 72.864-71.424a72.303 72.303 0 0 0-31.793-60.453"/>
+    <path fill="#34A853" d="M71.87 205.796h55.593V161.29H71.87a27.275 27.275 0 0 1-11.399-2.498l-7.887 2.42-22.409 22.253-1.952 7.574c12.567 9.489 27.9 14.825 43.647 14.757"/>
+    <path fill="#FBBC05" d="M71.87 61.425C31.94 61.664-.237 94.228.001 134.159a72.301 72.301 0 0 0 28.222 56.88l32.248-32.246c-13.99-6.322-20.208-22.786-13.887-36.776 6.32-13.99 22.786-20.208 36.775-13.888a27.796 27.796 0 0 1 13.887 13.888l32.248-32.248A72.224 72.224 0 0 0 71.87 61.425"/>
+  </svg>
+  <strong>GCP</strong>
+</span>
+.
 
 ## How it works
 

--- a/style.css
+++ b/style.css
@@ -161,6 +161,28 @@ h3 {
     letter-spacing: -0.1px !important;
 }
 
+#body-content .cloud-provider {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
+#body-content .cloud-provider svg {
+    width: 1.15rem;
+    height: 1.15rem;
+    flex: none;
+}
+
+#body-content .cloud-provider-aws {
+    color: #111827;
+}
+
+.dark #body-content .cloud-provider-aws {
+    color: #f9fafb;
+}
+
 #body-content span.method-nav-pill span {
     line-height: 1.25 !important;
 }


### PR DESCRIPTION
## Summary

Added inline SVG logos for AWS, Azure, and GCP next to their respective cloud provider names in the self-hosted documentation. Each logo is wrapped in a styled span with proper alignment and sizing. Added corresponding CSS styles to handle logo display, sizing, and dark mode support for AWS branding.

**Changes:**
- Embedded AWS, Azure, and GCP SVG logos inline with cloud provider names
- Added `.cloud-provider` class for flex layout and alignment
- Added `.cloud-provider-aws` class for AWS-specific text color (dark/light mode support)
- SVG logos sized at 1.15rem with proper vertical alignment 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/0723bf51-2067-41ea-8c4a-8d4c01159ab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.4?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.4?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.4?theme=light&v=11" height="28"></picture></a> 