### PR TITLE
Fix cloud provider label contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -176,8 +176,12 @@ h3 {
 }
 
 #body-content .cloud-provider-label {
-    color: #ffffff;
+    color: #111827;
     font-weight: 600;
+}
+
+.dark #body-content .cloud-provider-label {
+    color: #f9fafb;
 }
 
 #body-content .cloud-provider-aws {


### PR DESCRIPTION
## Summary

Improved contrast for cloud provider labels ("AWS, GCP, Azure") in light mode by changing text color from white (`#ffffff`) to dark gray (`#111827`). Added dark mode support with light gray text (`#f9fafb`) to maintain readability across both themes.

**Changes:**
- Updated `.cloud-provider-label` color for light mode
- Added `.dark #body-content .cloud-provider-label` rule for dark mode 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/f5b52a78-e6c1-4288-93d8-31bd0fe2d2f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/opencode:kimi-k2p6?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/opencode:kimi-k2p6?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/opencode:kimi-k2p6?theme=light&v=11" height="28"></picture></a> 