### PR TITLE
Rename Automations to Agents

### DIFF
--- a/api/trigger-agent.mdx
+++ b/api/trigger-agent.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Trigger Agent'
+description: 'Trigger an agent with an arbitrary JSON payload.'
+openapi: 'POST /automation/{keyOrId}/trigger'
+---

--- a/api/trigger-automation.mdx
+++ b/api/trigger-automation.mdx
@@ -1,5 +1,0 @@
----
-title: 'Trigger Automation'
-description: 'Trigger an automation with an arbitrary JSON payload.'
-openapi: 'POST /automation/{keyOrId}/trigger'
----

--- a/docs.json
+++ b/docs.json
@@ -45,7 +45,7 @@
                     {
                         "group": "Features",
                         "pages": [
-                            "features/automations",
+                            "features/agents",
                             "features/coding-agents",
                             "features/models",
                             "features/feedback-loop",
@@ -120,9 +120,9 @@
                                 ]
                             },
                             {
-                                "group": "Automations",
+                                "group": "Agents",
                                 "pages": [
-                                    "api/trigger-automation"
+                                    "api/trigger-agent"
                                 ]
                             },
                             {
@@ -187,6 +187,14 @@
         {
             "source": "/admin/billing",
             "destination": "/resources/pricing"
+        },
+        {
+            "source": "/features/automations",
+            "destination": "/features/agents"
+        },
+        {
+            "source": "/api/trigger-automation",
+            "destination": "/api/trigger-agent"
         }
     ]
 }

--- a/features/agent-actions.mdx
+++ b/features/agent-actions.mdx
@@ -27,7 +27,7 @@ A single task can span multiple repositories. Tembo can use context from connect
 
 **Triage a Linear ticket in Slack**: A Slack message triggers Tembo to read the Linear ticket, scan the codebase for context, and post an explanation back to the Slack thread.
 
-**Summarize Sentry errors**: A daily automation fetches errors from Sentry, ranks them by impact, creates Linear tickets, and posts a summary to Slack.
+**Summarize Sentry errors**: A daily agent fetches errors from Sentry, ranks them by impact, creates Linear tickets, and posts a summary to Slack.
 
 **Enrich issues with context**: When a new issue is created, Tembo searches the codebase, pulls related Notion docs, and adds implementation hints as a comment.
 
@@ -37,6 +37,6 @@ A single task can span multiple repositories. Tembo can use context from connect
 
 ## How it works
 
-Agents access integrations through MCP servers. When you connect an integration or install an MCP server, it becomes available to agents during tasks and automations. No extra configuration needed.
+Agents access integrations through MCP servers. When you connect an integration or install an MCP server, it becomes available to agents during tasks and scheduled runs. No extra configuration needed.
 
 See [MCP](/integrations/mcp) for available servers.

--- a/features/agents.mdx
+++ b/features/agents.mdx
@@ -1,16 +1,16 @@
 ---
-title: "Automations"
+title: "Agents"
 description: "Run coding agents on a schedule or triggered by events."
 ---
 
 <Frame>
-  <img src="/images/automation-light.png" alt="Automations" className="block dark:hidden" />
-  <img src="/images/automation-dark.png" alt="Automations" className="hidden dark:block" />
+  <img src="/images/automation-light.png" alt="Agents" className="block dark:hidden" />
+  <img src="/images/automation-dark.png" alt="Agents" className="hidden dark:block" />
 </Frame>
 
 Run coding agents in the background, on a schedule or triggered by events. A Sentry error gets fixed within seconds. Docs stay in sync with your code. Security vulnerabilities get caught before they become problems.
 
-Each automation runs in a secure [sandbox](/features/sandbox-environment) with full codebase and repository access and your configured [MCP servers](/integrations/mcp).
+Each agent runs in a secure [sandbox](/features/sandbox-environment) with full codebase and repository access and your configured [MCP servers](/integrations/mcp).
 
 ## Triggers
 
@@ -18,7 +18,7 @@ These are just examples to give you a rough idea. You decide how to set this up,
 
 ### Scheduled
 
-Run automations at regular intervals.
+Run agents at regular intervals.
 
 | Schedule    | Example                                     |
 | ----------- | ------------------------------------------- |
@@ -41,28 +41,28 @@ React to events from your integrations in real-time.
 
 #### Trigger through webhooks
 
-You can trigger an automation on demand from external systems using the automation's [webhook trigger endpoint](/api/trigger-automation).
+You can trigger an agent on demand from external systems using the agent's [webhook trigger endpoint](/api/trigger-agent).
 
-The payload is passed to the automation as event context, so your instructions can reference it directly. For example, you could write instructions like _"Fix the issue at the URL provided in the event payload"_.
+The payload is passed to the agent as event context, so your instructions can reference it directly. For example, you could write instructions like _"Fix the issue at the URL provided in the event payload"_.
 
 #### Slash command trigger
 
-You can trigger a task with the selected automation by using slash commands.
+You can trigger a task with the selected agent by using slash commands.
 
 ```txt
-@tembo !<automationMacro>
+@tembo !<agentMacro>
 ```
 
-## Creating an automation
+## Creating an agent
 
 ### From a template
 
 <Frame>
-  <img src="/images/integrations-light.png" alt="Automation templates" className="block dark:hidden" />
-  <img src="/images/integrations-dark.png" alt="Automation templates" className="hidden dark:block" />
+  <img src="/images/integrations-light.png" alt="Agent templates" className="block dark:hidden" />
+  <img src="/images/integrations-dark.png" alt="Agent templates" className="hidden dark:block" />
 </Frame>
 
-1. Go to **Automations** in the [dashboard](https://app.tembo.io)
+1. Go to **Agents** in the [dashboard](https://app.tembo.io)
 2. Click **Templates**
 3. Pick a template and click **Use template**
 4. Customize the instructions and enable
@@ -71,7 +71,7 @@ You can trigger a task with the selected automation by using slash commands.
 
 ### From scratch
 
-1. Click **New Automation**
+1. Click **New Agent**
 2. Write your instructions
 3. Add triggers (schedule and/or event-based)
 4. Select [coding agent](/features/coding-agents)
@@ -80,7 +80,7 @@ You can trigger a task with the selected automation by using slash commands.
 
 ## Beyond code
 
-Automations aren't limited to engineering tasks. With [MCP servers](/integrations/mcp), agents can work across your entire stack.
+Agents aren't limited to engineering tasks. With [MCP servers](/integrations/mcp), agents can work across your entire stack.
 
 | Example | Trigger | What it does |
 |---------|---------|-------------|
@@ -90,9 +90,9 @@ Automations aren't limited to engineering tasks. With [MCP servers](/integration
 | Enrich CRM records | New deal created | Pulls company info and adds context to [Attio](/integrations/mcp) or your CRM |
 | Create CRM tickets from Slack | `@tembo` in [Slack](/integrations/slack) | Creates a ticket in your CRM enriched with context from other connected integrations |
 
-Any tool with an [MCP server](/integrations/mcp) can be used in an automation.
+Any tool with an [MCP server](/integrations/mcp) can be used as an agent.
 
-You can also do this on-demand from [Slack](/integrations/slack) without setting up an automation:
+You can also do this on-demand from [Slack](/integrations/slack) without setting up an agent:
 
 ```
 @tembo What's our ARR right now? Check Stripe.

--- a/features/coding-agents.mdx
+++ b/features/coding-agents.mdx
@@ -3,7 +3,7 @@ title: "Coding Agents"
 description: "Choose from multiple AI coding agents to solve your software engineering tasks."
 ---
 
-Tembo is agent and model agnostic. Set a default agent and model per automation (e.g. all Linear issues use Codex with GPT-5.4) or override per task.
+Tembo is agent and model agnostic. Set a default coding agent and model per [agent](/features/agents) (e.g. all Linear issues use Codex with GPT-5.4) or override per task.
 
 See [Models](/features/models) for the full supported model list, BYOK details, and AWS Bedrock BYOK support.
 

--- a/features/self-hosted.mdx
+++ b/features/self-hosted.mdx
@@ -24,7 +24,7 @@ At a lower level, a standard deployment runs **6 core services**:
 - **Web app** for the user interface
 - **API** for product workflows, auth, and orchestration
 - **Sandbox service** for executing your tasks in isolated VMs
-- **Cron** for scheduled jobs (kicked off from tembo's `Automations` feature or via tool calls from coding agents)
+- **Cron** for scheduled jobs (kicked off from tembo's `Agents` feature or via tool calls from coding agents)
 - **Redis**
 - **Postgres**
 

--- a/index.mdx
+++ b/index.mdx
@@ -18,7 +18,7 @@ Delegate work to any coding agent. Tembo works autonomously with Claude Code, Cu
 ## What you can do with Tembo
 
 <CardGroup cols={3}>
-  <Card title="Automate tasks" icon="repeat" href="/features/automations">
+  <Card title="Automate tasks" icon="repeat" href="/features/agents">
     Set up recurring workflows triggered by events or schedules.
   </Card>
   <Card title="Fix bugs" icon="bug" href="/learn/fix-production-bugs">
@@ -77,7 +77,7 @@ Tembo is agent and model agnostic. Pick the right tool for each task. Tag `@temb
   <Card title="Quickstart" icon="rocket" href="/quickstart">
     Get up and running with Tembo in minutes.
   </Card>
-  <Card title="Automations" icon="repeat" href="/features/automations">
+  <Card title="Agents" icon="repeat" href="/features/agents">
     Set up event-driven workflows that run automatically.
   </Card>
 </CardGroup>

--- a/integrations/bitbucket.mdx
+++ b/integrations/bitbucket.mdx
@@ -40,9 +40,9 @@ Add `/tembo` in any pull request comment to request changes. Tembo reads the fee
 
 Works on PRs created by Tembo and PRs created by your team.
 
-## Automations
+## Agents
 
-See [Automations](/features/automations) for available Bitbucket event triggers.
+See [Agents](/features/agents) for available Bitbucket event triggers.
 
 ## Advanced
 

--- a/integrations/github.mdx
+++ b/integrations/github.mdx
@@ -50,9 +50,9 @@ Comment `@tembo` on any issue to start implementation. Tembo reads the issue tit
 @tembo Implement the API endpoint described in this issue
 ```
 
-## Automations
+## Agents
 
-See [Automations](/features/automations#event-driven) for available GitHub event triggers.
+See [Agents](/features/agents#event-driven) for available GitHub event triggers.
 
 ### PR reviews
 

--- a/integrations/gitlab.mdx
+++ b/integrations/gitlab.mdx
@@ -40,13 +40,13 @@ Comment `@tembo` on any merge request to request changes. Works in the main thre
 
 Works on MRs created by Tembo and MRs created by your team.
 
-## Automations
+## Agents
 
-See [Automations](/features/automations) for available GitLab event triggers.
+See [Agents](/features/agents) for available GitLab event triggers.
 
 ### Failed pipelines
 
-Tembo can detect CI/CD pipeline failures and open fix MRs automatically. Set up an [automation](/features/automations) with a pipeline failure trigger.
+Tembo can detect CI/CD pipeline failures and open fix MRs automatically. Set up an [agent](/features/agents) with a pipeline failure trigger.
 
 ## Advanced
 

--- a/integrations/jira.mdx
+++ b/integrations/jira.mdx
@@ -33,9 +33,9 @@ Add the "Tembo" label to any issue. Tembo reads the description, creates a codin
 
 To target a specific repo, add a `tembo/{repo-name}` label (e.g., `tembo/frontend`).
 
-## Automations
+## Agents
 
-See [Automations](/features/automations) for available Jira event triggers.
+See [Agents](/features/agents) for available Jira event triggers.
 
 ## Advanced
 

--- a/integrations/linear.mdx
+++ b/integrations/linear.mdx
@@ -34,9 +34,9 @@ Assign a Linear issue to Tembo. Select one or more repositories when prompted. T
 
 For multi-repo tasks, select multiple repositories and Tembo coordinates changes across all of them. It can also handle repositories across different git providers when needed.
 
-## Automations
+## Agents
 
-See [Automations](/features/automations) for available Linear event triggers.
+See [Agents](/features/agents) for available Linear event triggers.
 
 ## Advanced
 

--- a/integrations/sentry.mdx
+++ b/integrations/sentry.mdx
@@ -35,9 +35,9 @@ description: "Automatic error detection and fix PRs."
 3. Tembo analyzes the codebase and opens a fix PR
 4. Use the [feedback loop](/features/feedback-loop) to iterate
 
-## Automations
+## Agents
 
-See [Automations](/features/automations) for available Sentry event triggers.
+See [Agents](/features/agents) for available Sentry event triggers.
 
 ## Advanced
 

--- a/integrations/slack.mdx
+++ b/integrations/slack.mdx
@@ -72,9 +72,9 @@ Click the options on Tembo's message in Slack to stop a running task without lea
 
 When done, Tembo posts PR links back to the thread.
 
-## Automations
+## Agents
 
-See [Automations](/features/automations) for available Slack event triggers.
+See [Agents](/features/agents) for available Slack event triggers.
 
 ## Advanced
 

--- a/learn/fix-production-bugs.mdx
+++ b/learn/fix-production-bugs.mdx
@@ -30,9 +30,9 @@ Navigate to the [Integrations page](https://app.tembo.io/integrations) and conne
 
 See the full [Sentry integration guide](/integrations/sentry) for details.
 
-### 2. Create an automation
+### 2. Create an agent
 
-Go to **Automations** in your dashboard and create a new automation with a Sentry event trigger.
+Go to **Agents** in your dashboard and create a new agent with a Sentry event trigger.
 
 **Trigger**: `sentry.issue.created` or `sentry.issue.regression`
 **[MCP Servers](/integrations/mcp)**: GitHub + Sentry

--- a/learn/implement-from-issues.mdx
+++ b/learn/implement-from-issues.mdx
@@ -9,7 +9,7 @@ Tembo picks up issues from your project management tools and writes code to solv
 
 <Steps>
   <Step title="Issue assigned">
-    Create or assign an issue in [Linear](/integrations/linear), [Jira](/integrations/jira), [GitHub](/integrations/github), or mention it in [Slack](/integrations/slack). Tembo picks it up via webhook or [automation](/features/automations) trigger.
+    Create or assign an issue in [Linear](/integrations/linear), [Jira](/integrations/jira), [GitHub](/integrations/github), or mention it in [Slack](/integrations/slack). Tembo picks it up via webhook or [agent](/features/agents) trigger.
   </Step>
   <Step title="Context gathered">
     Tembo reads the issue description, pulls in related code, linked docs, and conversation history to understand the full picture.
@@ -34,7 +34,7 @@ Navigate to the [Integrations page](https://app.tembo.io/integrations) and conne
 - [Slack](/integrations/slack)
 - [Notion](/integrations/notion)
 
-### Create an automation
+### Create an agent
 
 **Trigger**: Issue created, issue assigned, or label added
 **[MCP Servers](/integrations/mcp)**: GitHub + your issue tracker
@@ -61,5 +61,5 @@ Tembo generates solutions autonomously, but your team decides what gets deployed
 ## Best practices
 
 - **Write clear issue descriptions**: The more context in the issue, the better the implementation.
-- **Use labels**: Trigger [automations](/features/automations) only on specific labels (e.g., `tembo`, `auto-implement`) to control which issues get picked up.
+- **Use labels**: Trigger [agents](/features/agents) only on specific labels (e.g., `tembo`, `auto-implement`) to control which issues get picked up.
 - **Start with small tasks**: Begin with well-scoped bugs and small features before tackling larger work.

--- a/learn/keep-docs-in-sync.mdx
+++ b/learn/keep-docs-in-sync.mdx
@@ -19,7 +19,7 @@ Tembo monitors your codebase for changes and automatically updates your document
   </Step>
 </Steps>
 
-## Set up docs automation
+## Set up a docs agent
 
 ### On PR merge
 

--- a/learn/reduce-technical-debt.mdx
+++ b/learn/reduce-technical-debt.mdx
@@ -9,7 +9,7 @@ Tembo periodically analyzes your codebase to find technical debt, security vulne
 
 <Steps>
   <Step title="Scheduled scan">
-    An [automation](/features/automations) runs on a schedule (daily, weekly, or monthly) and scans your codebase for issues.
+    An [agent](/features/agents) runs on a schedule (daily, weekly, or monthly) and scans your codebase for issues.
   </Step>
   <Step title="Issues identified">
     The agent finds stale TODOs, security vulnerabilities, outdated dependencies, duplicated code, and other debt.
@@ -19,7 +19,7 @@ Tembo periodically analyzes your codebase to find technical debt, security vulne
   </Step>
 </Steps>
 
-## Set up tech debt automation
+## Set up a tech debt agent
 
 ### Security vulnerability scan
 

--- a/learn/review-changes.mdx
+++ b/learn/review-changes.mdx
@@ -25,9 +25,9 @@ Tembo reviews [pull requests](/features/pull-requests) automatically, checking f
 
 Navigate to the [Integrations page](https://app.tembo.io/integrations) and connect [GitHub](/integrations/github), [GitLab](/integrations/gitlab), or [Bitbucket](/integrations/bitbucket).
 
-### 2. Create an automation
+### 2. Create an agent
 
-Go to [Automations](/features/automations) in your dashboard and use the **PR Review** template, or create one from scratch.
+Go to [Agents](/features/agents) in your dashboard and use the **PR Review** template, or create one from scratch.
 
 **Trigger**: PR opened / PR updated (webhook from [GitHub](/integrations/github), [GitLab](/integrations/gitlab), or [Bitbucket](/integrations/bitbucket))
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -13,8 +13,8 @@ description: "Get up and running with Tembo in minutes."
   <Step title="Review the PR">
     Tembo works in a [sandbox](/features/sandbox-environment), writes the code, and opens a pull request. Review it, then mention `@tembo` in PR comments to request changes.
   </Step>
-  <Step title="Set up automations">
-    Go to [Automations](https://app.tembo.io/automations) and pick a template or create your own with custom triggers and schedules. See [Automations](/features/automations).
+  <Step title="Set up agents">
+    Go to [Agents](https://app.tembo.io/automations) and pick a template or create your own with custom triggers and schedules. See [Agents](/features/agents).
   </Step>
 </Steps>
 


### PR DESCRIPTION
Renames the Automations feature to Agents throughout the docs,
including page files, navigation, cross-references, and adds
redirects from the old URLs.
