### PR TITLE
Add 10-user limit to plans

### DIFF
--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -7,11 +7,18 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 
 ## Plans
 
-- **Free ($0/month)**: 10 credits per week
-- **Pro ($60/month)**: 100 credits per month with overage billing
-- **Max ($200/month)**: 400 credits per month with overage billing
+- **Free ($0/month)**: 10 credits per week, up to 10 users
+- **Pro ($60/month)**: 100 credits per month with overage billing, up to 10 users
+- **Max ($200/month)**: 400 credits per month with overage billing, up to 10 users
+- **Enterprise (custom pricing)**: custom credits and unlimited users
 
 Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until your weekly refresh, an upgrade, or an additional credit purchase.
+
+## User limits
+
+Free, Pro, and Max organizations can have up to 10 users. Enterprise organizations have unlimited users.
+
+If your organization needs a temporary or ad hoc exception, contact support. Tembo can apply an organization-level seat limit override without changing your public plan.
 
 ## How credits work
 


### PR DESCRIPTION
## Summary

Enforce 10-user limit on Free, Pro, and Max plans while keeping Enterprise unlimited. Added user limit features to pricing page and documentation, plus new section explaining user limits and override process via support.

**Changes:**
- Updated pricing tiers to display "Up to 10 users" for Free, Pro, and Max plans
- Added "Unlimited users" and "Seat limit overrides" to Enterprise tier features
- Updated pricing documentation with user limit details
- Added new "User limits" section explaining limits and override process 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/c4cf8226-c2d9-4c19-8974-98987a924927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> 