### PR TITLE
Update docs to use tembo.nix

### DIFF
--- a/features/sandbox-environment.mdx
+++ b/features/sandbox-environment.mdx
@@ -45,13 +45,13 @@ Both sandbox types come with:
 | **Containers** | Docker 28, Docker Compose 2.31 (Large VM only) |
 | **Other** | Git, curl, ShellCheck, httpie |
 
-<Note>Go, Rust, Java, and Elixir are available through Nix dev shells. Add a `flake.nix` to install language-specific tooling for your project.</Note>
+<Note>Go, Rust, Java, and Elixir are available through Nix dev shells. Add a `tembo.nix` to install language-specific tooling for your project.</Note>
 
 ## Add custom dependencies
 
-To add custom dependencies in the sandbox, include a `flake.nix` with `devShells.x86_64-linux.default`. Tembo automatically detects it and runs commands inside your Nix dev shell.
+To add custom dependencies in the sandbox, include a `tembo.nix` with `devShells.x86_64-linux.default`. Tembo automatically detects it and runs commands inside your Nix dev shell.
 
-Here is a minimal `flake.nix` example you can copy and adapt:
+Here is a minimal `tembo.nix` example you can copy and adapt:
 
 ```nix
 {


### PR DESCRIPTION
Replaced all references of `flake.nix` with `tembo.nix` in the Nix custom dependencies section and related notes in the docs to reflect the correct filename for Tembo's Nix dev shell support. 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/c002ff0e-1e45-40eb-b37e-87a24fb71faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C08S9PXF1KJ/p1778168096713579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>