### PR TITLE
Update/action pr

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +30,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MONOREPO_READ_TOKEN }}
         run: node scripts/update-changelog.mjs
 
-      - name: Commit if changed
+      - name: Commit and open PR if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -37,6 +40,13 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit."
           else
+            BRANCH="chore/changelog-update-$(date +%Y%m%d%H%M%S)"
+            git checkout -b "$BRANCH"
             git commit -m "chore(changelog): update self-hosted release notes"
-            git push
+            git push origin "$BRANCH"
+            gh pr create \
+              --title "chore(changelog): update self-hosted release notes" \
+              --body "Automated changelog update from the self-hosted release pipeline." \
+              --base main \
+              --head "$BRANCH"
           fi

--- a/features/self-hosted/environment-variables.mdx
+++ b/features/self-hosted/environment-variables.mdx
@@ -156,20 +156,20 @@ If you are unable to access this, please go to the installer at `http://<YOUR_IP
 | Key | Env Var | Default | Description |
 |-----|---------|---------|-------------|
 | `api.agentApiUrl` | `AGENT_API_URL` | — | URL for the agent API |
-| `api.agentSecretKey` | `TEMBO_AGENT_API_SECRET` | `temborules` | Secret key for agent auth |
+| `api.agentSecretKey` | `TEMBO_AGENT_API_SECRET` | — | Secret key for agent auth |
 | `api.base` | `API_BASE_URL` | `http://localhost:9854/` | Base URL for the API |
 | `api.clerkDashboardUrl` | `CLERK_DASHBOARD_URL` | — | Clerk dashboard URL |
 | `api.intercom.accessToken` | `INTERCOM_ACCESS_TOKEN` | — | Intercom API access token |
-| `api.metricsSecretKey` | `TEMBO_METRICS_SECRET_KEY` | `tembo` | Secret key for metrics |
+| `api.metricsSecretKey` | `TEMBO_METRICS_SECRET_KEY` | — | Secret key for metrics |
 | `api.prefix` | `API_PREFIX` | — | Optional prefix path for all routes |
 | `api.sentry.dsn` | `SENTRY_DSN` | — | Sentry DSN for error reporting |
 | `api.sentry.enabled` | `SENTRY_ENABLED` | `true` | Enable Sentry |
 | `api.showErrors` | `API_SHOW_ERRORS` | `true` | Show errors in API response |
-| `api.slackInternal.appId` | `SLACK_APP_ID` | `A098R0Q23GT` | Internal Slack app ID |
+| `api.slackInternal.appId` | `SLACK_APP_ID` | — | Internal Slack app ID |
 | `api.slackInternal.botToken` | `SLACK_BOT_TOKEN` | — | Internal Slack bot token |
 | `api.slackInternal.clientSecret` | `SLACK_CLIENT_SECRET` | — | Internal Slack client secret |
 | `api.slackInternal.enabled` | `SLACK_ENABLED` | `false` | Enable internal Slack |
-| `api.slackInternal.internalChannelId` | `SLACK_INTERNAL_CHANNEL_ID` | `C099AEFTN65` | Internal Slack channel ID |
+| `api.slackInternal.internalChannelId` | `SLACK_INTERNAL_CHANNEL_ID` | — | Internal Slack channel ID |
 | `api.slackInternal.signingSecret` | `SLACK_SIGNING_SECRET` | — | Internal Slack signing secret |
 
 ## Agent
@@ -207,7 +207,7 @@ If you are unable to access this, please go to the installer at `http://<YOUR_IP
 
 | Key | Env Var | Default | Description |
 |-----|---------|---------|-------------|
-| `jwt.secretKey` | `TEMBO_JWT_SECRET_KEY` | `tembo` | JWT secret key |
+| `jwt.secretKey` | `TEMBO_JWT_SECRET_KEY` | — | JWT secret key |
 
 ## Frontend
 


### PR DESCRIPTION
general cleanup and making the merge a pr instead of direct push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk automation and documentation changes; main impact is on the changelog update workflow behavior (now creates PRs instead of pushing directly), which could fail if permissions/`gh` CLI auth are misconfigured.
> 
> **Overview**
> Switches the `update-changelog` GitHub Action from directly pushing changelog commits to instead creating a timestamped branch and opening a PR via `gh pr create` (and adds required `pull-requests: write` permission).
> 
> Updates `features/self-hosted/environment-variables.mdx` to remove hardcoded default values for several secret keys (`TEMBO_AGENT_API_SECRET`, `TEMBO_METRICS_SECRET_KEY`, `SLACK_APP_ID`, `SLACK_INTERNAL_CHANNEL_ID`, `TEMBO_JWT_SECRET_KEY`), documenting them as having no default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b7b57d6fbe162e0bf29ca1ddb9796920711bc4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->