### PR TITLE
Fix pnpm dev script for INFISICAL_TOKEN

### DIFF
--- a/integrations/infisical.mdx
+++ b/integrations/infisical.mdx
@@ -33,6 +33,13 @@ infisical run -- bun run --watch index.ts
 infisical run -- next dev --turbopack --port 3000
 ```
 
+If your script cannot infer the Infisical project automatically, add
+`--projectId` before the command separator:
+
+```bash
+infisical run --projectId <project-id> -- bun run --watch index.ts
+```
+
 ## Optional overrides
 
 If you want to override defaults for `infisical run`, add these in **Settings -> Sandbox**:


### PR DESCRIPTION
Updated Infisical integration docs to include `--projectId` flag usage for `infisical run` command to ensure proper loading of INFISICAL_TOKEN secrets when running `pnpm run dev`.

Added example:
```
infisical run --projectId <project-id> -- bun run --watch index.ts
```
This helps when the script cannot infer the Infisical project automatically. 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/cd07fbe9-a469-444f-b750-9a92d12bbaaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> 