### PR TITLE
Fix OpenAPI spec paths in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -25,7 +25,7 @@
     },
     "favicon": "/favicon.ico",
     "api": {
-        "openapi": "/openapi.documented.yml"
+        "openapi": "openapi.documented.yml"
     },
     "integrations": {
         "posthog": {
@@ -130,7 +130,7 @@
                     {
                         "group": "Tembo API",
                         "openapi": {
-                            "source": "/openapi.documented.yml",
+                            "source": "openapi.documented.yml",
                             "directory": "api"
                         },
                         "pages": [


### PR DESCRIPTION
## Summary
Updated OpenAPI spec paths in docs.json from absolute to relative paths to ensure correct referencing in the docs repo. 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/4265b8be-6a9f-475b-9d21-5ff9e76fb9ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just adjusts OpenAPI spec references in `docs.json`; impact is limited to docs generation/rendering if the relative path is incorrect.
> 
> **Overview**
> Updates `docs.json` to reference the OpenAPI spec via a *relative* path (removing the leading `/`) for both the top-level `api.openapi` setting and the `navigation` OpenAPI `source`, improving compatibility with how the docs repo resolves spec files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f75f9cc12a2bdabb4ffd73a8faeafd0af163624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->