### PR TITLE
removing env vars for now

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -68,7 +68,6 @@
                                             "features/self-hosted/deploy/azure"
                                         ]
                                     },
-                                    "features/self-hosted/environment-variables",
                                     "features/self-hosted/changelog"
                                 ]
                             },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs navigation-only change with no product, API, or deployment impact.
> 
> **Overview**
> Removes the **Environment variables** page from the Self-Hosted docs sidebar in `docs.json`, so `features/self-hosted/environment-variables` is no longer linked under Deploy/changelog. The page content may still exist on disk; only the Mintlify navigation entry is dropped for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc3c9d676e0123a5098fc0e9b78333348948263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->