### PR TITLE
Update supported models table

### DIFF
--- a/features/models.mdx
+++ b/features/models.mdx
@@ -35,10 +35,14 @@ The table below reflects the models currently supported by Tembo.
 
 | Model | Model ID | Provider | BYOK Required |
 | --- | --- | --- | --- |
+| Fable 5 | `claude-fable-5` | Anthropic | No |
+| Opus 4.8 | `claude-opus-4-8` | Anthropic | No |
+| Opus 4.7 | `claude-opus-4-7` | Anthropic | No |
 | Opus 4.6 | `claude-opus-4-6` | Anthropic | No |
 | Sonnet 4.6 | `claude-sonnet-4-6` | Anthropic | No |
 | Opus 4.5 | `claude-opus-4-5` | Anthropic | No |
 | Haiku 4.5 | `claude-4-5-haiku` | Anthropic | No |
+| GPT-5.5 | `gpt-5.5` | OpenAI | Yes |
 | GPT-5.4 | `gpt-5.4` | OpenAI | Yes |
 | GPT-5.4 Mini | `gpt-5.4-mini` | OpenAI | No |
 | GPT-5.4 Nano | `gpt-5.4-nano` | OpenAI | No |
@@ -46,19 +50,21 @@ The table below reflects the models currently supported by Tembo.
 | GPT-5.3 Codex Spark | `gpt-5.3-codex-spark` | OpenAI | Yes |
 | GPT-5.2 Codex | `gpt-5.2-codex` | OpenAI | No |
 | GPT-5.2 | `gpt-5.2` | OpenAI | Yes |
-| GPT-5.1 Codex Max | `gpt-5.1-codex-max` | OpenAI | Yes |
-| GPT-5.1 Codex Mini | `gpt-5.1-codex-mini` | OpenAI | Yes |
-| GPT-5.1 | `gpt-5.1` | OpenAI | Yes |
 | GLM 5.1 | `glm-5p1` | Z.ai | No |
+| GLM 4.7 | `zai-glm-4.7` | Z.ai | No |
 | Composer 1.5 | `composer-1.5` | Cursor | Yes |
 | Composer 2 | `composer-2` | Cursor | Yes |
 | Composer 2 Fast | `composer-2-fast` | Cursor | Yes |
-| Gemini 3 Pro | `gemini-3-pro` | Google | No |
+| Composer 2.5 | `composer-2.5` | Cursor | Yes |
 | Gemini 3.1 Pro | `gemini-3.1-pro` | Google | No |
 | Gemini 3 Flash | `gemini-3-flash` | Google | No |
 | Grok | `grok` | xAI | Yes |
-| Kimi K2.5 | `kimi-k2p5` | Fireworks | No |
-| MiniMax M2.5 | `minimax-m2p5` | MiniMax | No |
+| Kimi K2.6 | `kimi-k2p6` | Fireworks | No |
+| MiniMax M2.7 | `minimax-m2p7` | MiniMax | No |
+| DeepSeek V4 Pro | `deepseek-v4-pro` | DeepSeek | No |
+| DeepSeek V4 Flash | `deepseek-v4-flash` | DeepSeek | No |
+| Qwen 3 32B | `qwen-3-32b` | Qwen | No |
+| Llama 3.3 70B | `llama-3.3-70b` | Meta | No |
 
 <Note>
   Model availability can vary by agent and workspace configuration. If a model is disabled in your workspace, it will not appear in agent pickers until re-enabled.


### PR DESCRIPTION
## Summary
- Sync the supported models table on `/features/models` with the current model registry (`apps/api/src/server/models.ts` in the monorepo)
- Added: Fable 5, Opus 4.8, Opus 4.7, GPT-5.5, GLM 4.7, Composer 2.5, DeepSeek V4 Pro/Flash, Qwen 3 32B, Llama 3.3 70B
- Removed: GPT-5.1 / GPT-5.1 Codex Max / GPT-5.1 Codex Mini, Gemini 3 Pro
- Updated: Kimi K2.5 → K2.6, MiniMax M2.5 → M2.7

## Note
`claude-fable-5` is in the registry without an `isInternal` flag, so it's included here — drop that row if it isn't publicly announced yet.
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/f1caf0fe-4823-40c1-91ca-626dd2c68d9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-fable-5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-fable-5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-fable-5?theme=light&v=11" height="28"></picture></a> 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a single MDX table; no application or security impact.
> 
> **Overview**
> **Updates the `/features/models` supported-models table** so it matches the current product model registry.
> 
> **Adds** several Anthropic, OpenAI, Z.ai, Cursor, DeepSeek, Qwen, and Meta entries (including **Fable 5**, **Opus 4.8/4.7**, **GPT-5.5**, **GLM 4.7**, **Composer 2.5**, **DeepSeek V4 Pro/Flash**, **Qwen 3 32B**, **Llama 3.3 70B**). **Removes** legacy GPT-5.1 variants and **Gemini 3 Pro**. **Renames** Kimi and MiniMax rows to **K2.6** and **M2.7** with updated model IDs.
> 
> No runtime or API behavior changes—docs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c52c1e36ea9501fac44fbddde77e6e19c28b86a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->