### PR TITLE
docs(nav): add environment variables page to self-hosted section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -69,7 +69,8 @@
                                             "features/self-hosted/deploy/azure"
                                         ]
                                     },
-                                    "features/self-hosted/changelog"
+                                    "features/self-hosted/changelog",
+                                    "features/self-hosted/environment-variables"
                                 ]
                             },
                             {


### PR DESCRIPTION
The `features/self-hosted/environment-variables` page was reachable only via the link from the AWS deployment guide. This adds it to the Self-Hosted navigation group so users can discover the full configuration reference from the docs sidebar.
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@staging-tembo` and i'll get back to work! 


 <a href="https://app.tembo-staging.com/sessions/8bda0c39-3e13-44f6-840d-3371cbcac940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo-staging.com/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo-staging.com/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo-staging.com/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo-staging.com/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo-staging.com/public/agent-button/opencode:kimi-k2p7-code?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo-staging.com/public/agent-button/opencode:kimi-k2p7-code?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo-staging.com/public/agent-button/opencode:kimi-k2p7-code?theme=light&v=11" height="28"></picture></a> 