### PR TITLE
fix(aws-docs): tell users to find org ID from Open AWS Console URL

### DIFF
--- a/files/tembo-identity.json
+++ b/files/tembo-identity.json
@@ -4,7 +4,7 @@
   "Parameters": {
     "TemboOrgId": {
       "Type": "String",
-      "Description": "Your Tembo organization ID (shown in the connect modal)",
+      "Description": "Your Tembo organization ID — click 'Open AWS Console' in the Tembo connect modal and copy the param_TemboOrgId value from the URL",
       "MinLength": 1
     }
   },

--- a/integrations/aws.mdx
+++ b/integrations/aws.mdx
@@ -116,7 +116,7 @@ Use this if the one-click CloudFormation link shows "Access Denied". The templat
 4. Choose **Upload a template file** and upload `tembo-identity.json`.
 5. Enter the **Tembo organization ID** you copied in step 1 when prompted.
 6. Deploy the stack. When it completes, open the **Outputs** tab and copy the `RoleArn` value.
-6. Back in Tembo, switch to **Enter ARN manually** and paste the ARN. Click **Connect**.
+7. Back in Tembo, switch to **Enter ARN manually** and paste the ARN. Click **Connect**.
 
 ## How authentication works
 

--- a/integrations/aws.mdx
+++ b/integrations/aws.mdx
@@ -48,7 +48,7 @@ Use this if the one-click CloudFormation link shows "Access Denied". The templat
 2. Download the CloudFormation template. It creates an OIDC provider and a cross-account IAM role that trusts Tembo's issuer, scoped to your org ID.
 
 <div style={{marginLeft:'24px'}}>
-  <a href="/files/tembo-identity.json" download="tembo-identity.json">
+  <a href="https://tembo-public-resources-us-east-1.s3.us-east-1.amazonaws.com/aws-cf-identity/tembo-identity.json" download="tembo-identity.json">
     <button>Download tembo-identity.json</button>
   </a>
 </div>

--- a/integrations/aws.mdx
+++ b/integrations/aws.mdx
@@ -43,7 +43,9 @@ You can connect multiple AWS accounts — each gets its own label and isolated M
 
 Use this if the one-click CloudFormation link shows "Access Denied". The template below creates the same IAM resources.
 
-1. Download the CloudFormation template. It creates an OIDC provider and a cross-account IAM role that trusts Tembo's issuer, scoped to your org ID.
+1. **Find your org ID.** In the connect modal, click **Open AWS Console**. Before the AWS page loads, copy the `param_TemboOrgId` value from the URL — it looks like `org_2vyf1Ja...`. You'll need this in step 4.
+
+2. Download the CloudFormation template. It creates an OIDC provider and a cross-account IAM role that trusts Tembo's issuer, scoped to your org ID.
 
 <div style={{marginLeft:'24px'}}>
   <a href="/files/tembo-identity.json" download="tembo-identity.json">
@@ -58,7 +60,7 @@ Use this if the one-click CloudFormation link shows "Access Denied". The templat
   "Parameters": {
     "TemboOrgId": {
       "Type": "String",
-      "Description": "Your Tembo organization ID (shown in the connect modal)",
+      "Description": "Your Tembo organization ID (copy param_TemboOrgId from the Open AWS Console URL)",
       "MinLength": 1
     }
   },
@@ -110,10 +112,10 @@ Use this if the one-click CloudFormation link shows "Access Denied". The templat
   **Self-hosted Tembo:** replace both occurrences of `app.tembo.io` with your instance's public hostname (the value of `TEMBO_OIDC_ISSUER` in your config).
 </Note>
 
-2. In the [AWS CloudFormation console](https://console.aws.amazon.com/cloudformation), click **Create stack → With new resources**.
-3. Choose **Upload a template file** and upload `tembo-identity.json`.
-4. Enter your **Tembo organization ID** when prompted (visible in the connect modal).
-5. Deploy the stack. When it completes, open the **Outputs** tab and copy the `RoleArn` value.
+3. In the [AWS CloudFormation console](https://console.aws.amazon.com/cloudformation), click **Create stack → With new resources**.
+4. Choose **Upload a template file** and upload `tembo-identity.json`.
+5. Enter the **Tembo organization ID** you copied in step 1 when prompted.
+6. Deploy the stack. When it completes, open the **Outputs** tab and copy the `RoleArn` value.
 6. Back in Tembo, switch to **Enter ARN manually** and paste the ARN. Click **Connect**.
 
 ## How authentication works
@@ -133,7 +135,7 @@ Tembo never stores AWS credentials. For each agent run:
   </Accordion>
 
   <Accordion title="STS AssumeRoleWithWebIdentity fails after deploy">
-    Confirm the OIDC provider URL in your CloudFormation stack matches your Tembo instance exactly (including protocol, no trailing slash). For hosted Tembo this is `https://app.tembo.io`. Check that the `TemboOrgId` parameter matches the organization ID shown in the Tembo connect modal.
+    Confirm the OIDC provider URL in your CloudFormation stack matches your Tembo instance exactly (including protocol, no trailing slash). For hosted Tembo this is `https://app.tembo.io`. Check that the `TemboOrgId` parameter matches the organization ID from the `param_TemboOrgId` value in the Open AWS Console URL.
   </Accordion>
 
   <Accordion title="Agent can't reach AWS APIs">


### PR DESCRIPTION
## What
- Added step 1 to manual CloudFormation setup directing users to click **Open AWS Console** and copy `param_TemboOrgId` from the URL before proceeding
- Updated CloudFormation JSON parameter description to match
- Updated troubleshooting accordion — removed stale reference to org ID being visible in the connect modal

## Why
- The docs previously said the org ID was "shown in the connect modal"
- The org ID is available in the pre-filled CloudFormation URL (`param_TemboOrgId=org_...`) — the most accessible place for users doing manual setup

## References

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and template description text only; no runtime or IAM behavior changes.
> 
> **Overview**
> **AWS integration docs** no longer claim the Tembo org ID appears in the connect modal. Manual CloudFormation setup now starts with copying **`param_TemboOrgId`** from the **Open AWS Console** link before downloading or deploying the template, and later steps reference that value instead of the modal.
> 
> The downloadable template link points at the **public S3** `tembo-identity.json` (not the site `/files/` path). **`TemboOrgId`** descriptions in `tembo-identity.json` and the embedded doc snippet match the URL-based instructions. **Troubleshooting** for `AssumeRoleWithWebIdentity` failures is aligned to the same source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36480b97837891cde9633efd6adb75dba9b22554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->