### PR TITLE
docs: fix self-hosted integration urls

### DIFF
--- a/features/self-hosted/integrations/github.mdx
+++ b/features/self-hosted/integrations/github.mdx
@@ -38,7 +38,7 @@ This is important — it ensures that when a user installs the app, they are als
 ### Webhook URL
 
 ```
-http://<your-instance-ip>/api/webhooks/github
+http://<your-instance-ip>/api/webhook/github
 ```
 
 ### Webhook secret

--- a/features/self-hosted/integrations/slack.mdx
+++ b/features/self-hosted/integrations/slack.mdx
@@ -29,7 +29,7 @@ The Slack integration allows Tembo to send notifications, receive commands, and 
 1. In the left sidebar, go to **OAuth & Permissions**
 2. Under **Redirect URLs**, add:
    ```
-   http://<your-instance-ip>/api/oauth/authorize/slack
+   http://<your-instance-ip>/api/oauth/slack/callback
    ```
 3. Under **Bot Token Scopes**, add the following scopes:
 
@@ -58,7 +58,10 @@ The Slack integration allows Tembo to send notifications, receive commands, and 
 
    - `channels:history`
    - `im:history`
-   - `search:read`
+   - `search:read.public`
+   - `search:read.im`
+   - `search:read.files`
+   - `search:read.users`
    - `users:read`
    - `users:read.email`
 


### PR DESCRIPTION
## Summary

- Correct the self-hosted GitHub webhook URL to the API route Tembo serves.
- Correct the Slack OAuth redirect URL and user-token search scopes.

## Validation

- `mintlify validate`
- `git diff --check`
- checked merge conflicts against `origin/main`
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/87a60537-29e6-4bf3-b2ae-0ccccddb50d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C094UFXHKKP/p1782153632263699?thread_ts=1782152738.016719&cid=C094UFXHKKP"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>