### PR TITLE
docs: add data handling, update delivery, and credit overage details

### DIFF
--- a/features/sandbox/overview.mdx
+++ b/features/sandbox/overview.mdx
@@ -5,6 +5,14 @@ description: 'Secure, isolated environments where coding agents execute sessions
 
 Every session runs in its own isolated sandbox. Sandboxes are ephemeral: spun up for the session, destroyed when it's done. No code or state persists after execution.
 
+## Data handling
+
+Your repository is cloned into the sandbox for the duration of a session and torn down when the session ends — no repository contents or working state persist afterward.
+
+The one exception is snapshots. If you use the snapshot feature to speed up environment setup, your repository and pre-installed dependencies are cached into a reusable snapshot image so future sessions start faster. That cached copy persists until the snapshot is rebuilt or removed.
+
+Model providers handle prompt data according to their own retention policies — see the retention table in [Max](/features/max) for Tembo-hosted models. With [BYOK](/features/models), model requests run against your own provider account, so provider-side retention follows that account's terms.
+
 ## Sandbox sizes
 
 Tembo offers five sandbox sizes. Each session runs in a dedicated Linux VM, and no two sessions share the same VM.

--- a/features/self-hosted/overview.mdx
+++ b/features/self-hosted/overview.mdx
@@ -27,11 +27,11 @@ A standard deployment runs these core services, all behind nginx on port 80:
 |---|---|
 | **Web app** | Next.js frontend for the user interface |
 | **API** | REST API for product workflows, auth, and orchestration |
-| **Agent workers** | 1–64 configurable workers that handle sessions, code execution, and database operations in isolated sandboxes |
+| **Agent workers** | Configurable workers (default 8) that handle sessions, code execution, and database operations in isolated sandboxes |
 | **Cron** | Scheduled jobs, kicked off from Tembo's `Agents` feature or via tool calls from coding agents |
 | **Admin UI** | Administrative dashboard for system management |
-| **PostgreSQL 16** | Application database — runs locally or can point to an external instance using your own connection string |
-| **Redis** | Caching and job queuing |
+| **PostgreSQL 16** | Application database (and the job queue) — runs locally or can point to an external instance using your own connection string |
+| **Redis** | Caching |
 | **Prometheus** | Metrics collection and monitoring (optional) |
 
 ## Web-based installer
@@ -39,6 +39,15 @@ A standard deployment runs these core services, all behind nginx on port 80:
 Every deployment ships with a built-in installer at `/installer/`. On first boot, it walks you through setup — configuring services, setting your license key, and tuning options like the number of agent workers. No Nix knowledge is required.
 
 For releases and updates, Tembo can manage them for you, or your team can manually opt in to changes through the installer UI.
+
+### How updates are delivered
+
+Updates are **pull-based**. Your instance checks for new releases by calling Tembo's release endpoint over outbound HTTPS, authenticated with your license key, then downloads the packaged release. Tembo never connects inbound to your environment to push updates. Because the stack is NixOS-based, updates apply atomically and roll back automatically if they fail.
+
+You choose how updates are applied:
+
+- **Self-service:** your team opts in to a new release through the installer UI, on your own schedule.
+- **Managed (optional):** if you would rather Tembo run updates for you, we can do so as an optional service using access you explicitly grant. Contact your Tembo account team to set this up.
 
 ## What you manage
 

--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -31,6 +31,20 @@ Credits are used for:
 - Optimizing database queries and indexes
 - Processing pull request feedback through the [Feedback Loop](/features/feedback-loop)
 
+## When credits run out
+
+What happens when your balance reaches zero depends on your plan and overage setting:
+
+- **Free**: new sessions are blocked until your weekly credit refresh, an upgrade, or a credit purchase.
+- **Pro or Max with overages enabled**: sessions continue and are billed as overage, up to the maximum overage limit you set. Once that limit is reached, new sessions are blocked.
+- **Pro or Max with overages disabled**: new sessions are blocked as soon as included credits are exhausted.
+
+When work is blocked, the request is rejected immediately rather than queued. A session already in progress is allowed to finish its current step.
+
+## Usage bursts
+
+Some integrations can create a large batch of work at once — for example, a repository or integration sync, or a token refresh that triggers a backlog of issues. Tembo does not cap or rate-limit how much work an integration enqueues; the batch is processed as worker capacity becomes available, and each resulting session consumes credits when it runs. The same credit and overage limits above apply, so a burst cannot spend beyond your included credits plus your overage limit. To absorb large bursts without interruption, enable overages with an appropriate limit, or use [auto-reload](#auto-reload).
+
 ## Credit refunds
 
 You may receive automatic refunds in some cases:


### PR DESCRIPTION
## Summary

Adds documentation covering data handling, self-hosted update delivery, and credit overage behavior.

- **Sandbox** (`features/sandbox/overview.mdx`): new *Data handling* section documenting how repository data is cloned/torn down per session, the snapshot caching exception, and model provider retention (Max-hosted vs BYOK).
- **Self-hosted** (`features/self-hosted/overview.mdx`): corrected agent worker description (configurable, default 8), clarified PostgreSQL also serves the job queue and Redis is caching only, and added a *How updates are delivered* section explaining pull-based updates and self-service vs managed options.
- **Pricing** (`resources/pricing.mdx`): new *When credits run out* section (per-plan behavior on zero balance) and *Usage bursts* section (how batched integration work is processed and bounded by credit/overage limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation only; no application, infrastructure, or security logic changes.
> 
> **Overview**
> **Docs-only** expansion of customer-facing behavior around sandboxes, self-hosted operations, and billing.
> 
> **Sandbox overview** adds a **Data handling** section: per-session clone/teardown, the **snapshot** caching exception, and where model prompt retention is documented (Max-hosted vs BYOK).
> 
> **Self-hosted overview** tightens the services table—agent workers described as **configurable (default 8)** instead of a 1–64 range, **PostgreSQL** called out as app DB **and job queue**, **Redis** as caching only—and adds **How updates are delivered**: **pull-based** releases over outbound HTTPS with license auth, plus **self-service** vs optional **managed** update paths.
> 
> **Pricing** adds **When credits run out** (Free vs Pro/Max with or without overages, immediate rejection vs in-flight step completion) and **Usage bursts** (integrations can enqueue large batches without rate limits; spend still bounded by credits/overage; pointers to overages and auto-reload).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 142eebaf907e35c960f0e0a772156012eef5916e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->