### PR TITLE
adding azure and s3 storage docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -74,7 +74,9 @@
                                         "group": "Integrations",
                                         "pages": [
                                             "features/self-hosted/integrations/github",
-                                            "features/self-hosted/integrations/slack"
+                                            "features/self-hosted/integrations/slack",
+                                            "features/self-hosted/integrations/aws-storage",
+                                            "features/self-hosted/integrations/azure-storage"
                                         ]
                                     }
                                 ]

--- a/features/self-hosted/integrations/aws-storage.mdx
+++ b/features/self-hosted/integrations/aws-storage.mdx
@@ -1,0 +1,159 @@
+---
+title: 'AWS S3 Storage'
+description: 'Configure Amazon S3 for Tembo self-hosted on AWS.'
+---
+
+Tembo can use an S3 bucket as a single store for image attachments, org profile pictures, VM snapshots, and user storage. If you skip this configuration, file upload features will be unavailable.
+
+---
+
+## Step 1: Create an S3 Bucket
+
+### Via the AWS CLI
+
+```bash
+aws s3api create-bucket \
+  --bucket <bucket-name> \
+  --region us-east-1
+```
+
+For regions other than `us-east-1`, add the location constraint:
+
+```bash
+aws s3api create-bucket \
+  --bucket <bucket-name> \
+  --region us-west-2 \
+  --create-bucket-configuration LocationConstraint=us-west-2
+```
+
+### Via the AWS Console
+
+1. Go to **S3** → **Create bucket**
+2. Enter a **Bucket name** (globally unique)
+3. Select your **AWS Region**
+4. Leave all other settings as default and click **Create bucket**
+
+---
+
+## Step 2: Create IAM Credentials
+
+Tembo needs an IAM user with read/write access to the bucket. If your EC2 instance already has an IAM instance profile with S3 access, you can skip this step — Tembo will use the instance's credentials automatically.
+
+### Via the AWS CLI
+
+```bash
+# Create the IAM user
+aws iam create-user --user-name tembo-storage
+
+# Create an inline policy granting access to the bucket
+aws iam put-user-policy \
+  --user-name tembo-storage \
+  --policy-name tembo-s3-access \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+      "Resource": [
+        "arn:aws:s3:::<bucket-name>",
+        "arn:aws:s3:::<bucket-name>/*"
+      ]
+    }]
+  }'
+
+# Create access keys
+aws iam create-access-key --user-name tembo-storage
+```
+
+Note the `AccessKeyId` and `SecretAccessKey` from the output.
+
+### Via the AWS Console
+
+1. Go to **IAM** → **Users** → **Create user**
+2. Enter a username (e.g. `tembo-storage`) and click **Next**
+3. Select **Attach policies directly**, then click **Create policy**
+4. In the policy editor, paste:
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [{
+       "Effect": "Allow",
+       "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+       "Resource": [
+         "arn:aws:s3:::<bucket-name>",
+         "arn:aws:s3:::<bucket-name>/*"
+       ]
+     }]
+   }
+   ```
+5. Name the policy (e.g. `tembo-s3-access`) and click **Create policy**
+6. Back on the user creation page, attach the new policy and click **Next** → **Create user**
+7. Open the user, go to the **Security credentials** tab, and click **Create access key**
+8. Select **Application running outside AWS**, then click **Next** → **Create access key**
+9. Copy the **Access key** and **Secret access key**
+
+---
+
+## Step 3: Configure CORS
+
+Tembo uploads image attachments directly from the browser to S3. S3 blocks these cross-origin requests by default, so you must add a CORS rule.
+
+### Via the AWS CLI
+
+```bash
+aws s3api put-bucket-cors \
+  --bucket <bucket-name> \
+  --cors-configuration '{
+    "CORSRules": [{
+      "AllowedOrigins": ["http://<instance-ip>"],
+      "AllowedMethods": ["GET", "PUT", "DELETE", "HEAD"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": [],
+      "MaxAgeSeconds": 3600
+    }]
+  }'
+```
+
+If you are using a custom domain, replace `http://<instance-ip>` with your domain.
+
+### Via the AWS Console
+
+1. Go to **S3** → select your bucket → **Permissions** tab
+2. Scroll to **Cross-origin resource sharing (CORS)** and click **Edit**
+3. Paste:
+   ```json
+   [
+     {
+       "AllowedOrigins": ["http://<instance-ip>"],
+       "AllowedMethods": ["GET", "PUT", "DELETE", "HEAD"],
+       "AllowedHeaders": ["*"],
+       "ExposeHeaders": [],
+       "MaxAgeSeconds": 3600
+     }
+   ]
+   ```
+4. Click **Save changes**
+
+---
+
+## Step 4: Add to config.json
+
+Open `/var/lib/tembo/config.json` (via the VS Code server at `http://<instance-ip>:8888` or SSH) and add:
+
+```json
+{
+  "selfHosted.objectStorage.provider": "aws",
+  "selfHosted.objectStorage.bucket": "<bucket-name>",
+  "aws.region": "us-east-1",
+  "selfHosted.objectStorage.aws.accessKeyId": "<access-key-id>",
+  "selfHosted.objectStorage.aws.secretAccessKey": "<secret-access-key>"
+}
+```
+
+If your EC2 instance has an IAM instance profile with S3 access, omit `accessKeyId` and `secretAccessKey` — Tembo will use the instance's credentials automatically.
+
+Then restart the API:
+
+```bash
+sudo systemctl restart tembo-ts-api
+```

--- a/features/self-hosted/integrations/azure-storage.mdx
+++ b/features/self-hosted/integrations/azure-storage.mdx
@@ -1,0 +1,122 @@
+---
+title: 'Azure Storage'
+description: 'Configure Azure Blob Storage for Tembo self-hosted on Azure.'
+---
+
+Tembo can use an Azure Blob Storage container as a single bucket for image attachments, org profile pictures, VM snapshots, and user storage. If you skip this configuration, file upload features will be unavailable.
+
+---
+
+## Step 1: Create a Storage Account
+
+### Via the Azure CLI
+
+```bash
+az storage account create \
+  --name <storage-account-name> \
+  --resource-group tembo-self-hosted-rg \
+  --location eastus \
+  --sku Standard_LRS
+```
+
+### Via the Azure Portal
+
+1. Go to **Storage accounts** → **+ Create**
+2. Select your subscription and resource group
+3. Enter a **Storage account name** (globally unique, 3–24 characters, lowercase alphanumeric only)
+4. Choose your **Region**
+5. Leave **Redundancy** as **Locally-redundant storage (LRS)**
+6. Click **Review + create**, then **Create**
+
+---
+
+## Step 2: Create the Container
+
+### Via the Azure CLI
+
+```bash
+az storage container create \
+  --name <container-name> \
+  --account-name <storage-account-name>
+```
+
+### Via the Azure Portal
+
+1. Go to **Storage accounts** → select your account
+2. In the left sidebar, under **Data storage**, click **Containers**
+3. Click **+ Container**
+4. Enter a name and click **Create**
+
+---
+
+## Step 3: Get the Account Key
+
+### Via the Azure CLI
+
+```bash
+az storage account keys list \
+  --account-name <storage-account-name> \
+  --resource-group tembo-self-hosted-rg \
+  --query "[0].value" -o tsv
+```
+
+### Via the Azure Portal
+
+1. Go to **Storage accounts** → select your account
+2. In the left sidebar, under **Security + networking**, click **Access keys**
+3. Click **Show** next to **key1** and copy the **Key** value
+
+---
+
+## Step 4: Configure CORS
+
+Tembo uploads image attachments directly from the browser to the storage container. Azure blocks these cross-origin requests by default, so you must add a CORS rule.
+
+### Via the Azure CLI
+
+```bash
+az storage cors add \
+  --account-name <storage-account-name> \
+  --services b \
+  --methods DELETE GET HEAD OPTIONS PUT \
+  --origins 'http://<vm-ip>' \
+  --allowed-headers '*' \
+  --exposed-headers '*' \
+  --max-age 3600
+```
+
+If you are using a custom domain, replace `http://<vm-ip>` with your domain.
+
+### Via the Azure Portal
+
+1. Go to **Storage accounts** → select your account
+2. In the left sidebar, under **Settings**, click **Resource sharing (CORS)**
+3. Select the **Blob service** tab
+4. Click **+ Add** and fill in:
+   - **Allowed origins**: `http://<vm-ip>` (or your domain)
+   - **Allowed methods**: `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PUT`
+   - **Allowed headers**: `*`
+   - **Exposed headers**: `*`
+   - **Max age**: `3600`
+5. Click **Save**
+
+---
+
+## Step 5: Add to config.json
+
+Open `/var/lib/tembo/config.json` (via the VS Code server at `http://<vm-ip>:8888` or SSH) and add:
+
+```json
+{
+  "selfHosted.objectStorage.provider": "azure",
+  "selfHosted.objectStorage.bucket": "<container-name>",
+  "selfHosted.objectStorage.azure.storageAccountName": "<storage-account-name>",
+  "selfHosted.objectStorage.azure.storageAccountKey": "<account-key>"
+}
+```
+
+Then restart the API:
+
+```bash
+sudo systemctl restart tembo-ts-api
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or infrastructure code modifications.
> 
> **Overview**
> Adds self-hosted documentation for **object storage** on AWS and Azure so operators can enable file uploads (attachments, profile pictures, VM snapshots, user storage).
> 
> New pages **`aws-storage.mdx`** and **`azure-storage.mdx`** walk through creating the bucket/container, credentials (including optional EC2 instance profile on AWS), **CORS** for browser-direct uploads, and the relevant **`selfHosted.objectStorage.*`** entries in `/var/lib/tembo/config.json`, followed by restarting **`tembo-ts-api`**.
> 
> **`docs.json`** now lists both guides under **Self-Hosted → Integrations** alongside GitHub and Slack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13934d74f2520531efdb44d767fa012d8c9d1c37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->