### PR TITLE
docs(pricing): update free plan copy

### DIFF
--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -7,11 +7,11 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 
 ## Plans
 
-- **Free ($0/month)**: 10 credits per week
+- **Free**: $10 one time
 - **Pro ($60/month)**: 100 credits per month, up to 10 users, with overage billing
 - **Max ($200/month)**: 400 credits per month, up to 10 users, with overage billing
 
-Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until your weekly refresh, an upgrade, or an additional credit purchase.
+Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until an upgrade or an additional credit purchase.
 
 BYOK (Bring Your Own Key) is available only on the Enterprise plan.
 
@@ -37,7 +37,7 @@ Credits are used for:
 
 What happens when your balance reaches zero depends on your plan and overage setting:
 
-- **Free**: new sessions are blocked until your weekly credit refresh, an upgrade, or a credit purchase.
+- **Free**: new sessions are blocked until an upgrade or a credit purchase.
 - **Pro or Max with overages enabled**: sessions continue and are billed as overage, up to the maximum overage limit you set. Once that limit is reached, new sessions are blocked.
 - **Pro or Max with overages disabled**: new sessions are blocked as soon as included credits are exhausted.
 


### PR DESCRIPTION
## summary
- update the free plan pricing copy to say `$10 one time`
- remove weekly refresh references from free-plan exhaustion copy

## validation
- ran `git diff --check`
- fetched and merged `origin/main`; branch was already up to date with no conflicts
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/2fd7c51a-798f-4d68-93d0-7a33111c7104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C08S9PXF1KJ/p1783689588874029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no code, billing logic, or security impact.
> 
> **Overview**
> **Free plan** copy in `pricing.mdx` now describes **Free** as **$10 one time** instead of **$0/month with 10 credits per week**.
> 
> When credits are exhausted on Free, the doc no longer mentions a weekly refresh. Sessions stay blocked until **upgrade** or **additional credit purchase** in both the paid-plans intro and the **When credits run out** section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a07b7dc717716e0d3fe32ae900d7d851fddf2a92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->