### PR TITLE
docs: update plan seat limits

### DIFF
--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -11,8 +11,6 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 - **Pro ($60/month)**: 100 credits per month, up to 10 users, with overage billing
 - **Max ($200/month)**: 400 credits per month, up to 25 users, with overage billing
 
-Custom plans can include custom seat limits.
-
 Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until an upgrade or an additional credit purchase.
 
 BYOK (Bring Your Own Key) is available only on the Enterprise plan.

--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -7,9 +7,11 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 
 ## Plans
 
-- **Free**: $10 one time
+- **Free**: $10 one time, up to 3 users
 - **Pro ($60/month)**: 100 credits per month, up to 10 users, with overage billing
-- **Max ($200/month)**: 400 credits per month, up to 10 users, with overage billing
+- **Max ($200/month)**: 400 credits per month, up to 25 users, with overage billing
+
+Custom plans can include custom seat limits.
 
 Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until an upgrade or an additional credit purchase.
 


### PR DESCRIPTION
## what
- Update pricing docs to show current Clerk-hosted workspace seat limits: Free 3, Pro 10, Max 25.
- Note that custom plans can have custom seat limits.

## validation
- Checked branch is up to date with origin/main before commit.
- Reviewed the MDX diff.

## reference
- tembo/monorepo#9408
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/ddc986bd-0e47-4172-a41f-0834fc33c979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C094UFXHKKP/p1783703135330529?thread_ts=1783703121.369959&cid=C094UFXHKKP"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to plan seat copy; no product or billing logic is modified.
> 
> **Overview**
> Updates **`resources/pricing.mdx`** so plan copy matches current workspace seat caps.
> 
> **Free** now states **up to 3 users** on the one-time $10 tier. **Max** is updated from **10** to **25 users**; **Pro** stays at **10 users**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be42ff38cfe3fc8f24e883618b8674062fa5217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->