### PR TITLE
Update plan seat limits

### DIFF
--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -8,8 +8,8 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 ## Plans
 
 - **Free**: $10 one time, up to 3 users
-- **Pro ($60/month)**: 100 credits per month, up to 10 users, with overage billing
-- **Max ($200/month)**: 400 credits per month, up to 25 users, with overage billing
+- **Pro ($60/month)**: 100 credits per month, up to 5 users, with overage billing
+- **Max ($200/month)**: 400 credits per month, up to 10 users, with overage billing
 
 Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until an upgrade or an additional credit purchase.
 


### PR DESCRIPTION
## summary

- update pricing docs to pro 5 users and max 10 users

## validation

- git diff --check
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/08abd44e-13e0-44bf-8103-ed6989d6d6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C08S9PXF1KJ/p1783955145905849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to plan seat counts; no application or billing logic is modified in this PR.
> 
> **Overview**
> Updates **Pro** and **Max** seat caps in `resources/pricing.mdx` so they match current plan limits.
> 
> **Pro** is now documented as **up to 5 users** (was 10). **Max** is **up to 10 users** (was 25). Monthly price, credits, and overage wording are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 469a28f63ec8407cd2b900c35c816c2fe60d04d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->