### PR TITLE
docs(api): update agent trigger references

### DIFF
--- a/api/trigger-agent.mdx
+++ b/api/trigger-agent.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'Trigger Agent'
 description: 'Trigger an agent with an arbitrary JSON payload.'
-openapi: 'POST /automation/{keyOrId}/trigger'
+openapi: 'POST /agent/{keyOrId}/trigger'
 ---

--- a/docs.json
+++ b/docs.json
@@ -165,6 +165,7 @@
                             {
                                 "group": "Agents",
                                 "pages": [
+                                    "POST /agent",
                                     "api/trigger-agent"
                                 ]
                             },

--- a/integrations/snowflake.mdx
+++ b/integrations/snowflake.mdx
@@ -9,7 +9,7 @@ description: "Call Tembo from Snowflake Cortex Agents via the Model Context Prot
 
 ## Overview
 
-This integration is the inverse of most Tembo integrations: Snowflake is the **MCP client** and Tembo is the **MCP server**. Once configured, your Snowflake users can ask a Cortex Agent things like *"list my Tembo sessions"* or *"trigger a Tembo automation on issue X"* directly from **Snowflake Intelligence** chat — the same surface they already use for Cortex Analyst and Cortex Search.
+This integration is the inverse of most Tembo integrations: Snowflake is the **MCP client** and Tembo is the **MCP server**. Once configured, your Snowflake users can ask a Cortex Agent things like *"list my Tembo sessions"* or *"trigger a Tembo agent on issue X"* directly from **Snowflake Intelligence** chat — the same surface they already use for Cortex Analyst and Cortex Search.
 
 The integration is implemented as a Snowflake-managed MCP server that exposes Tembo's public REST API as a set of `GENERIC` tools. The API token lives in Snowflake's secret store; agents call the tools through a Python UDF that handles auth and routing.
 
@@ -103,7 +103,7 @@ ROUTES = {
     "search_sessions":    ("GET",  "/session/search"),
     "list_repositories":  ("GET",  "/repository/list"),
     "create_session":     ("POST", "/session/create"),
-    "trigger_automation": ("POST", "/automation/{keyOrId}/trigger"),
+    "trigger_agent":      ("POST", "/agent/{keyOrId}/trigger"),
 }
 
 def handler(tool, args):
@@ -176,13 +176,13 @@ tools:
     title: "Create Tembo Session"
     input_constants:
       tool: "create_session"
-  - name: "trigger_automation"
+  - name: "trigger_agent"
     type: "GENERIC"
     identifier: "<db>.<schema>.tembo_call"
-    description: "Trigger a Tembo automation. Pass { keyOrId: '<uuid_or_macro>', ...payload } in args."
-    title: "Trigger Tembo Automation"
+    description: "Trigger a Tembo agent. Pass { keyOrId: '<uuid_or_macro>', ...payload } in args."
+    title: "Trigger Tembo Agent"
     input_constants:
-      tool: "trigger_automation"
+      tool: "trigger_agent"
 $$;
 ```
 
@@ -202,7 +202,7 @@ $$
 COMMENT = 'Chat with Tembo from inside Snowflake'
 FROM SPECIFICATION $$
 instructions:
-  orchestration: "When the user asks about Tembo sessions, repos, or automations, use the Tembo MCP tools."
+  orchestration: "When the user asks about Tembo sessions, repos, or agents, use the Tembo MCP tools."
 mcp_servers:
   - server_spec:
       name: "<db>.<schema>.tembo_mcp_server"
@@ -237,7 +237,7 @@ GRANT USAGE ON AGENT my_tembo_agent                 TO ROLE <user_role>;
 3. Try one of:
    - *"Show me my five most recent Tembo sessions."*
    - *"Which repositories are enabled for Tembo?"*
-   - *"Trigger the Tembo automation `daily-triage` with `{ priority: 'high' }`."*
+   - *"Trigger the Tembo agent `daily-triage` with `{ priority: 'high' }`."*
 
 The agent calls `tools/list` against `tembo_mcp_server`, picks the right `GENERIC` tool, which routes through `tembo_call` → Tembo REST API → response.
 

--- a/openapi.documented.yml
+++ b/openapi.documented.yml
@@ -398,11 +398,11 @@ paths:
                       const response = await client.session.search({ q: 'authentication bug' });
 
                       console.log(response.issues);
-    /automation/{keyOrId}/trigger:
+    /agent/{keyOrId}/trigger:
         post:
             responses:
                 "200":
-                    description: Automation triggered successfully
+                    description: Agent triggered successfully
                     content:
                         application/json:
                             schema:
@@ -415,7 +415,7 @@ paths:
                                     task:
                                         type: string
                                         description: The type of job that was queued
-                                        example: RunWorkflow
+                                        example: RunAgent
                                     status:
                                         type: string
                                         description: Current status of the job
@@ -438,7 +438,7 @@ paths:
                                     - createdAt
                                     - updatedAt
                 "404":
-                    description: Automation not found (no automation with the given key or ID exists in your organization)
+                    description: Agent not found (no agent with the given key or ID exists in your organization)
                     content:
                         application/json:
                             schema:
@@ -446,14 +446,14 @@ paths:
                                 properties:
                                     error:
                                         type: string
-                                        example: Automation not found
+                                        example: Agent not found
                                 required:
                                     - error
-            operationId: postPublic-apiAutomationTrigger
+            operationId: postPublic-apiAgentTrigger
             parameters:
                 - name: keyOrId
                   in: path
-                  description: The automation's UUID or its macro (key). You can find the UUID in the automation's properties panel.
+                  description: The agent's UUID or its macro (key). You can find the UUID in the agent's properties panel.
                   required: true
                   schema:
                       type: string
@@ -465,12 +465,12 @@ paths:
                   schema:
                       type: string
             description: |-
-                Trigger an automation with an arbitrary JSON payload, which is passed to the automation as event context.
+                Trigger an agent with an arbitrary JSON payload, which is passed to the agent as event context.
 
-                You can identify the automation by either its UUID or its macro (key). The API key can be supplied via the `Authorization: Bearer` header or the `apiKey` query parameter.
-            summary: Trigger Automation
+                You can identify the agent by either its UUID or its macro (key). The API key can be supplied via the `Authorization: Bearer` header or the `apiKey` query parameter.
+            summary: Trigger Agent
             requestBody:
-                description: Arbitrary JSON payload passed to the automation as event context. Your automation instructions can reference any values in this payload.
+                description: Arbitrary JSON payload passed to the agent as event context. Your agent instructions can reference any values in this payload.
                 content:
                     application/json:
                         schema:
@@ -485,7 +485,7 @@ paths:
                   label: Bearer Auth
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/automation/${AUTOMATION_ID}/trigger" \
+                        "https://api.tembo.io/agent/${AGENT_ID}/trigger" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"issue_url": "https://github.com/org/repo/issues/42"}' | jq .
@@ -493,7 +493,7 @@ paths:
                   label: Query Param Auth
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/automation/${AUTOMATION_ID}/trigger?apiKey=${API_KEY}" \
+                        "https://api.tembo.io/agent/${AGENT_ID}/trigger?apiKey=${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"issue_url": "https://github.com/org/repo/issues/42"}' | jq .
     /repository/list:

--- a/openapi.documented.yml
+++ b/openapi.documented.yml
@@ -398,6 +398,174 @@ paths:
                       const response = await client.session.search({ q: 'authentication bug' });
 
                       console.log(response.issues);
+    /agent:
+        post:
+            responses:
+                "200":
+                    description: Agent created successfully
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    id:
+                                        type: string
+                                        format: uuid
+                                        description: Unique identifier for the agent
+                                    name:
+                                        type: string
+                                        description: Agent name
+                                        example: Daily triage
+                                    key:
+                                        type: string
+                                        nullable: true
+                                        description: Macro key generated for the agent
+                                        example: daily-triage
+                                    jsonContent:
+                                        type: object
+                                        nullable: true
+                                        additionalProperties: true
+                                        description: Agent instructions as a structured document
+                                    agent:
+                                        type: string
+                                        nullable: true
+                                        description: Agent harness or model to use
+                                        example: claudeCode:claude-opus-4-5
+                                    mcpServers:
+                                        type: array
+                                        items:
+                                            type: string
+                                        description: MCP servers available to the agent
+                                    organizationId:
+                                        type: string
+                                        format: uuid
+                                    enabledAt:
+                                        type: string
+                                        format: date-time
+                                        nullable: true
+                                    createdAt:
+                                        type: string
+                                        format: date-time
+                                    updatedAt:
+                                        type: string
+                                        format: date-time
+                                required:
+                                    - id
+                                    - name
+                                    - organizationId
+                                    - createdAt
+                                    - updatedAt
+                "400":
+                    description: Bad request - invalid input
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    error:
+                                        type: string
+                                required:
+                                    - error
+            operationId: postPublic-apiAgent
+            parameters: []
+            description: Create a new agent for your organization.
+            summary: Create Agent
+            requestBody:
+                description: Agent creation payload
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                name:
+                                    type: string
+                                    description: Agent name
+                                    example: Daily triage
+                                jsonContent:
+                                    type: object
+                                    additionalProperties: true
+                                    description: Agent instructions as a structured document
+                                    example:
+                                        type: doc
+                                        content:
+                                            - type: paragraph
+                                              content:
+                                                  - type: text
+                                                    text: Review new issues and summarize priority, owner, and next steps.
+                                mcpServers:
+                                    type: array
+                                    items:
+                                        type: string
+                                    description: MCP servers available to the agent
+                                    example:
+                                        - linear
+                                        - github
+                                agent:
+                                    type: string
+                                    description: Agent harness or model to use
+                                    example: claudeCode:claude-opus-4-5
+                                triggers:
+                                    type: array
+                                    description: Event triggers to attach to the agent
+                                    items:
+                                        type: object
+                                        properties:
+                                            name:
+                                                type: string
+                                                description: Trigger name
+                                                example: linear.issue.created
+                                            integrationId:
+                                                type: string
+                                                description: Integration ID for the trigger
+                                            filters:
+                                                type: object
+                                                additionalProperties: true
+                                                description: Trigger-specific filters
+                                        required:
+                                            - name
+                                schedules:
+                                    type: array
+                                    description: Schedules to attach to the agent
+                                    items:
+                                        type: object
+                                        properties:
+                                            cron:
+                                                type: string
+                                                description: Cron expression for the schedule
+                                                example: 0 9 * * 1-5
+                                        required:
+                                            - cron
+                            required:
+                                - name
+                                - jsonContent
+                required: true
+            x-codeSamples:
+                - lang: bash
+                  source: |-
+                      curl -s -X POST \
+                        "https://api.tembo.io/agent" \
+                        -H "Authorization: Bearer ${API_KEY}" \
+                        -H "Content-Type: application/json" \
+                        -d '{
+                          "name": "Daily triage",
+                          "jsonContent": {
+                            "type": "doc",
+                            "content": [
+                              {
+                                "type": "paragraph",
+                                "content": [
+                                  {
+                                    "type": "text",
+                                    "text": "Review new issues and summarize priority, owner, and next steps."
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "agent": "claudeCode:claude-opus-4-5",
+                          "mcpServers": ["linear", "github"],
+                          "schedules": [{ "cron": "0 9 * * 1-5" }]
+                        }' | jq .
     /agent/{keyOrId}/trigger:
         post:
             responses:


### PR DESCRIPTION
## summary
- update the trigger agent api reference from `/automation/{keyOrId}/trigger` to `/agent/{keyOrId}/trigger`
- update the queued task example from `RunWorkflow` to `RunAgent`
- align the snowflake integration example with the agent trigger endpoint and naming

## validation
- `git diff --check`
- parsed `openapi.documented.yml` with ruby yaml
- scanned touched docs for stale `/automation/{keyOrId}/trigger`, `RunWorkflow`, `run_workflow`, `workflowId`, and `.tembo/workflows` references
- confirmed branch contains latest `origin/main` and scanned changed files for conflict markers

## notes
- `mintlify build` could not run because `nix develop` failed while downloading from `cache.nixos.org` with `SSL certificate problem: certificate is not yet valid`.
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/edc7b461-be3b-4cfd-a317-d3517e73a601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C08S9PXF1KJ/p1784001137852329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI spec only; no runtime or auth changes.
> 
> **Overview**
> This PR **rebrands the public API docs from “automation” to “agent”** and documents the new agent endpoints.
> 
> **OpenAPI (`openapi.documented.yml`)** adds **`POST /agent`** (create agent with name, instructions, MCP servers, triggers, schedules) and moves the trigger operation to **`POST /agent/{keyOrId}/trigger`**, with copy, operation IDs, examples, and the queued job task example updated from **`RunWorkflow`** to **`RunAgent`**.
> 
> **Docs navigation** lists **`POST /agent`** under the Agents API group alongside the trigger reference page.
> 
> **`api/trigger-agent.mdx`** now points at **`POST /agent/{keyOrId}/trigger`**.
> 
> **Snowflake integration** updates the UDF route, MCP tool name (`trigger_agent`), prompts, and examples to use the agent trigger path and wording instead of automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252669f2c5ef91086bb1f99953b206aede5d5c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->