### PR TITLE
[Blocked on release of post-trigger hooks] Document trigger hook payload context

### DIFF
--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -54,9 +54,9 @@ When the script exits with a non-zero status, Tembo stops the run before the age
 
 ## Trigger payloads
 
-For triggered agent runs, Tembo exposes the trigger payload to the script through the `TRIGGER_PAYLOAD` environment variable. For webhook-triggered runs, this is the JSON request body sent to the [trigger endpoint](/api/trigger-agent).
+For triggered agent runs, Tembo exposes the trigger payload to the script through the `TRIGGER_PAYLOAD` environment variable. For most integration triggers, Tembo provides the payload shape automatically. For webhook-triggered runs, this is the JSON request body sent to the [trigger endpoint](/api/trigger-agent).
 
-Use the payload to decide what extra context to fetch and print. For example, the payload might identify a GitHub issue, Slack thread, Sentry event, Linear ticket, or any internal record your hook can look up before the agent starts.
+Use the payload to decide what extra context to fetch and print. For example, Tembo's preconfigured trigger payload might identify a GitHub issue, Slack thread, Sentry event, or Linear ticket that your hook can look up before the agent starts. If you trigger an agent through the webhook API, your own payload can identify any internal record the hook should fetch.
 
 ```bash
 #!/usr/bin/env bash

--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -56,22 +56,27 @@ When the script exits with a non-zero status, Tembo stops the run before the age
 
 For triggered agent runs, Tembo exposes the trigger payload to the script through the `TRIGGER_PAYLOAD` environment variable. For most integration triggers, Tembo provides the payload shape automatically. For webhook-triggered runs, this is the JSON request body sent to the [trigger endpoint](/api/trigger-agent).
 
-Use the payload to decide what extra context to fetch and print. For example, Tembo's preconfigured trigger payload might identify a GitHub issue, Slack thread, Sentry event, or Linear ticket that your hook can look up before the agent starts. If you trigger an agent through the webhook API, your own payload can identify any internal record the hook should fetch.
+Use the payload to decide what extra context to fetch, print, or validate. The agent receives both the trigger payload and the hook's standard output, so print the result of the check instead of restating fields that are already in the payload.
 
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
 
-issue_url="$(jq -r '.issue_url' <<< "$TRIGGER_PAYLOAD")"
-priority="$(jq -r '.priority // "normal"' <<< "$TRIGGER_PAYLOAD")"
+issue_identifier="$(jq -r '.issue.identifier // .issue.key // "unknown"' <<< "$TRIGGER_PAYLOAD")"
+description="$(jq -r '.issue.description // .issue.body // ""' <<< "$TRIGGER_PAYLOAD")"
 
-echo "## Trigger context"
+if [[ -z "${description//[[:space:]]/}" ]]; then
+  echo "Linear issue ${issue_identifier} does not have a description. Add implementation context before running Tembo." >&2
+  exit 1
+fi
+
+echo "## Linear ticket check"
 echo
-echo "- Issue URL: ${issue_url}"
-echo "- Priority: ${priority}"
+echo "- Issue: ${issue_identifier}"
+echo "- Description: present"
 ```
 
-The hook output above is appended to the agent's starting context. You do not need a separate API call to write that information into the agent thread.
+The hook output above is appended to the agent's starting context. If the description is missing, the non-zero exit code stops the agent before it starts.
 
 If the hook needs to fetch more detail, print the final useful summary, not only the raw payload:
 

--- a/features/agents.mdx
+++ b/features/agents.mdx
@@ -90,7 +90,9 @@ React to events from your integrations in real-time.
 
 You can trigger an agent on demand from external systems using the agent's [webhook trigger endpoint](/api/trigger-agent).
 
-The payload is passed to the agent as event context, so your instructions can reference it directly. For example, you could write instructions like _"Fix the issue at the URL provided in the event payload"_.
+The JSON payload is passed to the agent as event context, so your instructions can reference it directly. For example, you could write instructions like _"Fix the issue at the URL provided in the event payload"_.
+
+If you need to transform the payload or fetch extra data before the agent starts, use an [agent post-trigger hook](/beta/agent-post-trigger-hook). The hook can read `TRIGGER_PAYLOAD` and print Markdown, text, or JSON to standard output; Tembo adds that output to the agent's starting context.
 
 ## Creating an agent
 

--- a/openapi.documented.yml
+++ b/openapi.documented.yml
@@ -633,12 +633,14 @@ paths:
                   schema:
                       type: string
             description: |-
-                Trigger an agent with an arbitrary JSON payload, which is passed to the agent as event context.
+                Trigger an agent with an arbitrary JSON payload. Tembo passes the request body to the agent as event context, so the agent can use values such as issue URLs, ticket IDs, Slack thread links, Sentry event IDs, priorities, or customer-provided instructions.
+
+                If the agent has a post-trigger hook, Tembo also exposes the same request body to that hook as the `TRIGGER_PAYLOAD` environment variable. To add dynamically fetched context to the agent's starting thread, have the hook print the final useful context to standard output.
 
                 You can identify the agent by either its UUID or its macro (key). The API key can be supplied via the `Authorization: Bearer` header or the `apiKey` query parameter.
             summary: Trigger Agent
             requestBody:
-                description: Arbitrary JSON payload passed to the agent as event context. Your agent instructions can reference any values in this payload.
+                description: Arbitrary JSON payload passed to the agent as event context and, when configured, to the post-trigger hook as `TRIGGER_PAYLOAD`.
                 content:
                     application/json:
                         schema:
@@ -647,6 +649,7 @@ paths:
                             example:
                                 issue_url: https://github.com/org/repo/issues/42
                                 priority: high
+                                instructions: Reproduce the issue, fix it, and open a pull request.
                 required: false
             x-codeSamples:
                 - lang: bash


### PR DESCRIPTION
## Summary

- Updates the agents feature page to mention post-trigger hooks as an option for transforming webhook payloads or fetching extra context.
- Expands the trigger agent OpenAPI description to document `TRIGGER_PAYLOAD` behavior and expected hook output.
- Fixes the beta link target to `/beta/agent-post-trigger-hook`.

## Notes

This is stacked on top of #631 (`tembo/beta-agent-pre-run-script`) so the diff contains only the non-`beta/` documentation changes while the linked hidden beta page exists in the base branch.

## Validation

- Checked for merge conflicts against `origin/tembo/beta-agent-pre-run-script`: already up to date.
- Ran `git diff --check`.
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/65f59789-b0b9-4a63-9412-afbe6b91f7f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C08S9PXF1KJ/p1784249276862329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> **Documentation-only** updates for webhook agent triggers and post-trigger hooks.
> 
> On **features/agents.mdx**, the webhook section now states the trigger body is **JSON** event context and points readers to **[agent post-trigger hooks](/beta/agent-post-trigger-hook)** when they need to reshape the payload or fetch extra data. It documents that hooks read **`TRIGGER_PAYLOAD`** and that **stdout** (Markdown, text, or JSON) is merged into the agent’s starting context.
> 
> On **openapi.documented.yml**, the **Trigger Agent** operation description and request body text are expanded: the body is event context with concrete field examples (issue URLs, ticket IDs, Slack links, Sentry IDs, priorities, instructions). When a post-trigger hook is configured, the same body is available as **`TRIGGER_PAYLOAD`**, and hook **stdout** adds dynamic context. The OpenAPI example gains an **`instructions`** field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbcaeaa661a7bccb25c2022026e8a173c6016519. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->