### PR TITLE
Update post-trigger hook behavior explanation

### DIFF
--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -35,7 +35,7 @@ The script runs in `/workspace`, after Tembo sets up the repository and before t
 
 Post-trigger hooks impact triggered agent runs in two ways:
 
-1. When the script succeeds, Tembo captures what the script prints and adds it to the agent's starting thread as context. 
+1. When the script succeeds, Tembo captures what the script prints and adds it to the agent's starting thread as context.
 2. When the script fails (exits with a non-zero `exit` code), Tembo stops the run before the agent starts.
 
 Print the information the agent should use to standard output (e.g. `echo`). Markdown, plain text, and compact JSON all work well.

--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -33,7 +33,10 @@ The script runs in `/workspace`, after Tembo sets up the repository and before t
 
 ## How output affects the agent
 
-When the script succeeds, Tembo captures what the script prints and adds it to the agent's starting thread as pre-run context. This is the primary way to get dynamically fetched output into the agent run.
+Post-trigger hooks impact triggered agent runs in two ways:
+
+1. When the script succeeds, Tembo captures what the script prints and adds it to the agent's starting thread as context. 
+2. When the script fails (exits with a non-zero `exit` code), Tembo stops the run before the agent starts.
 
 Print the information the agent should use to standard output (e.g. `echo`). Markdown, plain text, and compact JSON all work well.
 
@@ -74,7 +77,7 @@ The hook output above is appended to the agent's starting context. If the descri
 
 ## Workspace resumes
 
-Tembo skips the pre-run script when resuming an existing workspace. If a job is retried, the script runs again before the agent starts.
+Tembo skips the post-tripper hook when resuming an existing workspace. If a job is retried, the script runs again before the agent starts.
 
 ## Related configuration
 

--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -77,7 +77,7 @@ The hook output above is appended to the agent's starting context. If the descri
 
 ## Workspace resumes
 
-Tembo skips the post-tripper hook when resuming an existing workspace. If a job is retried, the script runs again before the agent starts.
+Tembo skips the post-trigger hook when resuming an existing workspace. If a job is retried, the script runs again before the agent starts.
 
 ## Related configuration
 

--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Agent post-trigger hooks"
 description: "Run a custom setup script before an agent starts."
+public: true
 hidden: true
 ---
 


### PR DESCRIPTION
Clarify the impact of post-trigger hooks on agent runs, specifying behavior on success and failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only edits with no application or security impact.
> 
> **Overview**
> Updates the **agent post-trigger hooks** beta doc to spell out success vs failure behavior: stdout on success becomes starting-thread context; a non-zero exit stops the run before the agent starts.
> 
> Also adds `public: true` to frontmatter (alongside `hidden: true`) and renames **Workspace resumes** wording from “pre-run script” to **post-trigger hook** for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15659b6b5bb01df186b6d2c0d76ca3cab2cabec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->