### PR TITLE
Unhide post-trigger hooks

### DIFF
--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Agent post-trigger hooks"
 description: "Run a custom setup script before an agent starts."
-hidden: true
 ---
 
 <Warning>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only frontmatter change with no product or security impact.
> 
> **Overview**
> Removes the **`hidden: true`** frontmatter flag from `beta/agent-post-trigger-hook.mdx` so the agent post-trigger hooks doc can appear in the site navigation instead of being limited to direct URL access.
> 
> The in-page beta **Warning** (still noting the feature is beta and intentionally unlisted by URL) is unchanged; only doc visibility metadata is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e71722aa5982eb84b7ef5924399e6fa28e09aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->