### PR TITLE
Refactor error messages for missing ticket description

### DIFF
--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -65,7 +65,6 @@ issue_identifier="$(jq -r '.issue.identifier // .issue.key // "unknown"' <<< "$T
 description="$(jq -r '.issue.description // .issue.body // ""' <<< "$TRIGGER_PAYLOAD")"
 
 if [[ -z "${description//[[:space:]]/}" ]]; then
-```suggestion
   echo "Linear issue ${issue_identifier} does not have a description." >&2
   echo "Add implementation context before running Tembo." >&2
   exit 1

--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -59,13 +59,15 @@ For triggered agent runs, Tembo exposes the trigger payload to the script throug
 Use the payload to decide what extra context to fetch, print, or validate. The agent receives both the trigger payload and the hook's standard output, so there is no need to restate fields that are already in the payload.
 
 ```bash
-### Check if a Linear Ticket has a description before starting the session
+### Check if a Linear Ticket has a description 
+### before starting the session
 issue_identifier="$(jq -r '.issue.identifier // .issue.key // "unknown"' <<< "$TRIGGER_PAYLOAD")"
 description="$(jq -r '.issue.description // .issue.body // ""' <<< "$TRIGGER_PAYLOAD")"
 
 if [[ -z "${description//[[:space:]]/}" ]]; then
-  echo "Linear issue ${issue_identifier} does not have a description. Add implementation context before running Tembo." >&2
-  exit 1
+echo "Linear issue ${issue_identifier} does not have a description." >&2
+echo "Add implementation context before running Tembo." >&2
+exit 1
 fi
 ```
 

--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -65,9 +65,10 @@ issue_identifier="$(jq -r '.issue.identifier // .issue.key // "unknown"' <<< "$T
 description="$(jq -r '.issue.description // .issue.body // ""' <<< "$TRIGGER_PAYLOAD")"
 
 if [[ -z "${description//[[:space:]]/}" ]]; then
-echo "Linear issue ${issue_identifier} does not have a description." >&2
-echo "Add implementation context before running Tembo." >&2
-exit 1
+```suggestion
+  echo "Linear issue ${issue_identifier} does not have a description." >&2
+  echo "Add implementation context before running Tembo." >&2
+  exit 1
 fi
 ```
 


### PR DESCRIPTION
Updated the output messages for missing Linear Ticket description to improve clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an example in a hidden beta page; no product or runtime behavior changes.
> 
> **Overview**
> Updates the **post-trigger hook** beta doc’s Linear “missing description” example only.
> 
> The example comment title is split across two `###` lines so it reads more clearly in the bash block. When validation fails, the single long `stderr` message is replaced with **two** `echo` lines: one stating the issue lacks a description, and a second telling the user to add implementation context before running Tembo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e085c69c9b7df51304942001634c1cddf90e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->