### PR TITLE
Reorganize beta warning in agent post-trigger documentation

### DIFF
--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -5,10 +5,6 @@ public: true
 hidden: true
 ---
 
-<Warning>
-  This feature is in beta. This page is intentionally unlisted and available only by direct URL.
-</Warning>
-
 Agent post-trigger hooks are user-defined shell commands that run in the sandbox before a triggered agent starts. They execute after Tembo prepares the workspace but before the agent begins work.
 
 Use post-trigger hooks to provide the agent with context that can be deterministically fetched, or to check conditions before the agent runs. A non-zero exit code will prevent the agent from running.
@@ -19,6 +15,9 @@ Use post-trigger hooks to provide the agent with context that can be determinist
 </Note>
 
 ## Prerequisites
+<Warning>
+  This feature is in beta. This page is intentionally unlisted and available only by direct URL.
+</Warning>
 
 - Agent post-trigger hooks must be enabled for your organization or user account.
 - You need permission to edit the agent.

--- a/beta/agent-post-trigger-hook.mdx
+++ b/beta/agent-post-trigger-hook.mdx
@@ -15,6 +15,7 @@ Use post-trigger hooks to provide the agent with context that can be determinist
 </Note>
 
 ## Prerequisites
+
 <Warning>
   This feature is in beta. This page is intentionally unlisted and available only by direct URL.
 </Warning>


### PR DESCRIPTION
Removed warning about beta feature from the beginning and added it to the prerequisites section.

I just feel like this looks a lot better

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only reordering with no behavioral or code impact.
> 
> **Overview**
> Moves the **beta / unlisted page** `<Warning>` from the top of `agent-post-trigger-hook.mdx` into the **Prerequisites** section, right before the bullet list of requirements.
> 
> The warning text is unchanged; only placement changes so the intro reads without an immediate beta callout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a2aa241b3cb721058c28b69e1c5b2de27d8c03a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->