### PR TITLE
update pricing docs allowances

### DIFF
--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -8,8 +8,8 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 ## Plans
 
 - **Free**: $10 one time, up to 3 users
-- **Pro ($60/month)**: 100 credits per month, up to 5 users, with overage billing
-- **Max ($200/month)**: 400 credits per month, up to 10 users, with overage billing
+- **Pro ($60/month)**: 60 credits per month, up to 5 users, with overage billing
+- **Max ($200/month)**: 200 credits per month, up to 10 users, with overage billing
 
 Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until an upgrade or an additional credit purchase.
 


### PR DESCRIPTION
updates docs.tembo.io/resources/pricing so paid plan included credits match pricing v2.

- pro now shows 60 credits per month
- max now shows 200 credits per month
- removes the old 100/400 credit public copy from the pricing resource

linear: https://linear.app/tembo/issue/TEM-7643/pricing-v2-align-paid-plan-allowances 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/aaac85f1-8e7c-4482-bfb4-c45c375efeab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.5?theme=light&v=11" height="28"></picture></a> <a href="https://linear.app/tembo/issue/TEM-7643/pricing-v2-align-paid-plan-allowances"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/linear?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/linear?theme=light&v=2"><img alt="View on linear" src="https://internal.tembo.io/public/vendor-button/linear?theme=light&v=2" height="28"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to published plan allowances; no product or billing logic is modified.
> 
> **Overview**
> Updates the **Plans** section in `resources/pricing.mdx` so public copy matches **pricing v2** included credits.
> 
> **Pro** is now documented as **60 credits per month** (was 100). **Max** is now **200 credits per month** (was 400). Monthly prices, user limits, and overage wording are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80494057a98d4a9417cf6260a782c64c077f40c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->