### PR TITLE
Document sandbox size limits by plan

### DIFF
--- a/features/sandbox/overview.mdx
+++ b/features/sandbox/overview.mdx
@@ -28,7 +28,7 @@ Tembo offers six sandbox sizes. Each session runs in a dedicated Linux VM, and n
 
 Micro and Medium are best for routine code analysis, fixes, features, and reviews. Large, XL, and XXL are best for heavier builds, integration tests, Docker workloads, large repositories, or multi-container setups.
 
-Sandbox sizes larger than XXL require manual approval for your organization. Email [support@tembo.io](mailto:support@tembo.io) for access.
+Need more than 64 GB of RAM? Contact [support@tembo.io](mailto:support@tembo.io) to request access.
 
 VM sandboxes include full nested virtualization for Docker-in-Docker and provide a stronger isolation boundary.
 

--- a/features/sandbox/overview.mdx
+++ b/features/sandbox/overview.mdx
@@ -22,11 +22,13 @@ Tembo offers six sandbox sizes. Each session runs in a dedicated Linux VM, and n
 | Nano | 2 | 2 GB | 30 GB |
 | Micro | 2 | 4 GB | 50 GB |
 | Medium | 4 | 8 GB | 50 GB |
-| Large | 8 | 32 GB | 100 GB |
-| XL | 16 | 64 GB | 200 GB |
-| Ultra | 32 | 128 GB | 200 GB |
+| Large | 8 | 16 GB | 100 GB |
+| XL | 16 | 32 GB | 200 GB |
+| XXL | 16 | 64 GB | 200 GB |
 
-Micro and Medium are best for routine code analysis, fixes, features, and reviews. Large, XL, and Ultra are best for heavier builds, integration tests, Docker workloads, large repositories, or multi-container setups.
+Micro and Medium are best for routine code analysis, fixes, features, and reviews. Large, XL, and XXL are best for heavier builds, integration tests, Docker workloads, large repositories, or multi-container setups.
+
+Sandbox sizes larger than XXL require manual approval for your organization. Email [support@tembo.io](mailto:support@tembo.io) for access.
 
 VM sandboxes include full nested virtualization for Docker-in-Docker and provide a stronger isolation boundary.
 

--- a/features/sandbox/overview.mdx
+++ b/features/sandbox/overview.mdx
@@ -17,15 +17,6 @@ Model providers handle prompt data according to their own retention policies —
 
 Tembo offers six sandbox sizes. Each session runs in a dedicated Linux VM, and no two sessions share the same VM.
 
-Plan limits determine the largest sandbox size an organization can select:
-
-| Plan | Max sandbox size |
-|------|------------------|
-| Free | `nano` |
-| Pro | `large` |
-| Max | `ultra` |
-| Enterprise/custom | Custom or unlimited |
-
 | Size | vCPU | Memory | Disk |
 |------|------|--------|------|
 | Nano | 2 | 2 GB | 30 GB |

--- a/features/sandbox/overview.mdx
+++ b/features/sandbox/overview.mdx
@@ -15,10 +15,20 @@ Model providers handle prompt data according to their own retention policies —
 
 ## Sandbox sizes
 
-Tembo offers five sandbox sizes. Each session runs in a dedicated Linux VM, and no two sessions share the same VM.
+Tembo offers six sandbox sizes. Each session runs in a dedicated Linux VM, and no two sessions share the same VM.
+
+Plan limits determine the largest sandbox size an organization can select:
+
+| Plan | Max sandbox size |
+|------|------------------|
+| Free | `nano` |
+| Pro | `large` |
+| Max | `ultra` |
+| Enterprise/custom | Custom or unlimited |
 
 | Size | vCPU | Memory | Disk |
 |------|------|--------|------|
+| Nano | 2 | 2 GB | 30 GB |
 | Micro | 2 | 4 GB | 50 GB |
 | Medium | 4 | 8 GB | 50 GB |
 | Large | 8 | 32 GB | 100 GB |

--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -10,7 +10,6 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 - **Free**: $10 one time, up to 3 users, sandbox size up to `nano`
 - **Pro ($60/month)**: 60 credits per month, up to 5 users, sandbox size up to `large`, with overage billing
 - **Max ($200/month)**: 200 credits per month, up to 10 users, sandbox size up to `ultra`, with overage billing
-- **Enterprise/custom**: custom credit allocations and custom or unlimited sandbox sizing
 
 Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until an upgrade or an additional credit purchase.
 

--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -7,9 +7,11 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 
 ## Plans
 
-- **Free**: $10 one time, up to 3 users, sandbox size up to `nano`
-- **Pro ($60/month)**: 60 credits per month, up to 5 users, sandbox size up to `large`, with overage billing
-- **Max ($200/month)**: 200 credits per month, up to 10 users, sandbox size up to `ultra`, with overage billing
+- **Free**: $10 one time, up to 3 users, sandbox size up to `micro`
+- **Pro ($60/month)**: 60 credits per month, up to 5 users, sandbox size up to `medium`, with overage billing
+- **Max ($200/month)**: 200 credits per month, up to 10 users, sandbox size up to `xxl`, with overage billing
+
+Sandbox sizes larger than XXL require manual approval for your organization. Email [support@tembo.io](mailto:support@tembo.io) for access.
 
 Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until an upgrade or an additional credit purchase.
 

--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -7,9 +7,10 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 
 ## Plans
 
-- **Free**: $10 one time, up to 3 users
-- **Pro ($60/month)**: 60 credits per month, up to 5 users, with overage billing
-- **Max ($200/month)**: 200 credits per month, up to 10 users, with overage billing
+- **Free**: $10 one time, up to 3 users, sandbox size up to `nano`
+- **Pro ($60/month)**: 60 credits per month, up to 5 users, sandbox size up to `large`, with overage billing
+- **Max ($200/month)**: 200 credits per month, up to 10 users, sandbox size up to `ultra`, with overage billing
+- **Enterprise/custom**: custom credit allocations and custom or unlimited sandbox sizing
 
 Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until an upgrade or an additional credit purchase.
 
@@ -101,6 +102,7 @@ Need help? Contact [hi@tembo.io](mailto:hi@tembo.io).
 If you need custom pricing, reach out to [support@tembo.io](mailto:support@tembo.io) for:
 
 - Custom credit allocations
+- Custom or unlimited sandbox sizing
 - Volume pricing
 - BYOK (Bring Your Own Key)
 - Dedicated support

--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -11,7 +11,7 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 - **Pro ($60/month)**: 60 credits per month, up to 5 users, sandbox size up to `medium`, with overage billing
 - **Max ($200/month)**: 200 credits per month, up to 10 users, sandbox size up to `xxl`, with overage billing
 
-Sandbox sizes larger than XXL require manual approval for your organization. Email [support@tembo.io](mailto:support@tembo.io) for access.
+Need more than 64 GB of RAM? Contact [support@tembo.io](mailto:support@tembo.io) to request access.
 
 Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until an upgrade or an additional credit purchase.
 


### PR DESCRIPTION
## summary
- document the six standard sandbox sizes from Nano through XXL and remove Ultra
- align the published size specifications with the application configuration
- document the included plan limits: Free Micro, Pro Medium, and Max XXL
- explain that sizes larger than XXL require organization approval through support
- retain custom sandbox sizing in the enterprise pricing options

## validation
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to sandbox and pricing pages; no application or security impact.
> 
> **Overview**
> Updates customer-facing docs so **sandbox sizing** and **plan entitlements** match the current product lineup.
> 
> In **`features/sandbox/overview.mdx`**, the size catalog moves from five tiers to **six** (Nano through XXL): **Nano** is added, **Ultra** is removed, **XXL** replaces the old top tier, and **Large/XL** memory specs are revised (e.g. Large 32→16 GB, XL 64→32 GB). Guidance now points heavy workloads at Large/XL/XXL, with a note to contact support for **>64 GB RAM**.
> 
> In **`resources/pricing.mdx`**, each plan documents its **maximum sandbox size** (Free `micro`, Pro `medium`, Max `xxl`), repeats the >64 GB support path, and Enterprise pricing explicitly calls out **custom or unlimited sandbox sizing**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb26b143465d5b59b9efd5372e61ddca78f6b74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->