### PR TITLE
Remove max page from sidebar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -53,7 +53,6 @@
                             "features/agents",
                             "features/models",
                             "features/feedback-loop",
-                            "features/max",
                             {
                                 "group": "Sandbox",
                                 "pages": [


### PR DESCRIPTION
## Summary
Removed the 'features/max' page from the docs sidebar navigation in `docs.json` to hide it from the sidebar while keeping the page in the repo. 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@staging-tembo` and i'll get back to work! 


 <a href="https://app.tembo-staging.com/sessions/4ba05b0a-f0e3-4aa0-ad31-f276d462e415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo-staging.com/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo-staging.com/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo-staging.com/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a> <a href="https://app.tembo-staging.com/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo-staging.com/public/agent-button/codex:gpt-5.6-sol?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo-staging.com/public/agent-button/codex:gpt-5.6-sol?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo-staging.com/public/agent-button/codex:gpt-5.6-sol?theme=light&v=12" height="28"></picture></a> 