### PR TITLE
chore: rm xxl

### DIFF
--- a/features/sandbox/overview.mdx
+++ b/features/sandbox/overview.mdx
@@ -15,7 +15,7 @@ Model providers handle prompt data according to their own retention policies —
 
 ## Sandbox sizes
 
-Tembo offers six sandbox sizes. Each session runs in a dedicated Linux VM, and no two sessions share the same VM.
+Tembo offers five sandbox sizes. Each session runs in a dedicated Linux VM, and no two sessions share the same VM.
 
 | Size | vCPU | Memory | Disk |
 |------|------|--------|------|
@@ -24,11 +24,10 @@ Tembo offers six sandbox sizes. Each session runs in a dedicated Linux VM, and n
 | Medium | 4 | 8 GB | 50 GB |
 | Large | 8 | 16 GB | 100 GB |
 | XL | 16 | 32 GB | 200 GB |
-| XXL | 16 | 64 GB | 200 GB |
 
-Micro and Medium are best for routine code analysis, fixes, features, and reviews. Large, XL, and XXL are best for heavier builds, integration tests, Docker workloads, large repositories, or multi-container setups.
+Micro and Medium are best for routine code analysis, fixes, features, and reviews. Large and XL are best for heavier builds, integration tests, Docker workloads, large repositories, or multi-container setups.
 
-Need more than 64 GB of RAM? Contact [support@tembo.io](mailto:support@tembo.io) to request access.
+Need more than 32 GB of RAM? Contact [support@tembo.io](mailto:support@tembo.io) to request access.
 
 VM sandboxes include full nested virtualization for Docker-in-Docker and provide a stronger isolation boundary.
 

--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -9,9 +9,9 @@ Tembo uses subscription plans with credits so you can match usage to your team's
 
 - **Free**: $10 one time, up to 3 users, sandbox size up to `micro`
 - **Pro ($60/month)**: 60 credits per month, up to 5 users, sandbox size up to `medium`, with overage billing
-- **Max ($200/month)**: 200 credits per month, up to 10 users, sandbox size up to `xxl`, with overage billing
+- **Max ($200/month)**: 200 credits per month, up to 10 users, sandbox size up to `xl`, with overage billing
 
-Need more than 64 GB of RAM? Contact [support@tembo.io](mailto:support@tembo.io) to request access.
+Need more than 32 GB of RAM? Contact [support@tembo.io](mailto:support@tembo.io) to request access.
 
 Paid plans include overage billing so your work can continue after you use your monthly plan credits. You can set a maximum overage limit to control spend. On Free, sessions pause when credits are exhausted until an upgrade or an additional credit purchase.
 


### PR DESCRIPTION
## what

- Remove XXL from the documented sandbox-size table and guidance.
- Document XL as the Max plan's largest included sandbox size.
- Change the request-access contact line from more than 64 GB to more than 32 GB.

## why

- Keep the public documentation aligned with the Max plan's new XL limit and the current product offering.

## references

- Monorepo: https://github.com/tembo/monorepo/pull/9679
- Website: https://github.com/tembo/website/pull/551
