### PR TITLE
docs: add Tailscale integration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -130,7 +130,8 @@
                             "integrations/snowflake",
                             "integrations/snyk",
                             "integrations/stripe",
-                            "integrations/supabase"
+                            "integrations/supabase",
+                            "integrations/tailscale"
                         ]
                     },
                     {

--- a/integrations.mdx
+++ b/integrations.mdx
@@ -80,6 +80,9 @@ description: "Connect the tools Tembo can read from, trigger from, and act in."
   <Card title="Infisical" icon={<img src="/images/integrations/infisical.svg" alt="" />} href="/integrations/infisical">
     Inject secrets into Tembo-powered runs without committing .env files.
   </Card>
+  <Card title="Tailscale" icon="network-wired" href="/integrations/tailscale">
+    Connect sessions to your private network with on-demand ephemeral keys.
+  </Card>
 </CardGroup>
 
 ## Monitoring and security

--- a/integrations/tailscale.mdx
+++ b/integrations/tailscale.mdx
@@ -1,0 +1,180 @@
+---
+title: "Tailscale"
+description: "Connect Tembo sandbox sessions to your private network (tailnet) with on-demand, single-use ephemeral keys."
+---
+
+<Note>
+  The Tailscale integration is currently in preview. Contact
+  [support](/support) if you'd like it enabled for your organization.
+</Note>
+
+## Overview
+
+The Tailscale integration lets Tembo agent sessions join your
+[tailnet](https://tailscale.com/kb/1136/tailnet) so they can reach private
+resources — internal databases, staging hosts, admin APIs — that aren't
+exposed to the public internet.
+
+It is designed to be safe by default:
+
+- **Opt-in per task** — sessions never join your tailnet automatically. An
+  agent connects only when a task needs private-network access, using the
+  managed `/tailscale` skill the integration installs.
+- **Single-use, ephemeral keys** — each join uses a short-lived, single-use
+  auth key minted on demand. Your Tailscale OAuth credentials never enter a
+  sandbox, and ephemeral nodes remove themselves from your tailnet when the
+  session ends.
+- **Your ACLs decide access** — a joined session is just a tagged device on
+  your tailnet. What it can reach is governed entirely by your Tailscale ACL
+  policy for the tag you assign. No inbound access to the session is required
+  or expected.
+- **Unprivileged** — inside the sandbox, Tailscale runs in userspace
+  networking mode with no root access and no kernel networking changes.
+
+## Prerequisites
+
+You need admin access to your Tailscale organization to complete the setup:
+
+<Steps>
+  <Step title="Choose a device tag">
+    Sessions join your tailnet as tagged devices. We recommend a dedicated
+    tag such as `tag:tembo-session` so you can scope access rules to Tembo
+    sessions only.
+  </Step>
+  <Step title="Add the tag to your tailnet policy">
+    In the [Tailscale admin console](https://login.tailscale.com/admin/acls),
+    declare the tag in `tagOwners`:
+
+    ```jsonc
+    "tagOwners": {
+      "tag:tembo-session": [],
+    },
+    ```
+  </Step>
+  <Step title="Grant the tag access in your ACLs">
+    Add ACL rules for what Tembo sessions may reach. This is entirely your
+    choice — start narrow. For example, to allow sessions to reach a staging
+    database subnet and hosts tagged `tag:staging`:
+
+    ```jsonc
+    "acls": [
+      {
+        "action": "accept",
+        "src":    ["tag:tembo-session"],
+        "dst":    ["tag:staging:*", "10.20.0.0/16:5432"],
+      },
+    ],
+    ```
+
+    If you want agents to SSH into hosts via
+    [Tailscale SSH](https://tailscale.com/kb/1193/tailscale-ssh), add an
+    `ssh` rule as well:
+
+    ```jsonc
+    "ssh": [
+      {
+        "action": "accept",
+        "src":    ["tag:tembo-session"],
+        "dst":    ["tag:staging"],
+        "users":  ["ubuntu"],
+      },
+    ],
+    ```
+  </Step>
+  <Step title="Create an OAuth client">
+    In **Settings → OAuth clients**, create a client with the **Keys → Auth
+    keys** write scope, and assign it the tag you created
+    (`tag:tembo-session`). Tembo uses this client to mint short-lived auth
+    keys — it can only create keys for the tags it owns.
+
+    Copy the **client ID** and **client secret**; you'll enter them in Tembo
+    next.
+  </Step>
+</Steps>
+
+## Installation
+
+<Steps>
+  <Step title="Open Integrations">
+    In the Tembo app, go to **Settings → Integrations**.
+  </Step>
+  <Step title="Install Tailscale">
+    Find **Tailscale** in the **Developer Tools** group and click
+    **Install**.
+  </Step>
+  <Step title="Enter your OAuth client credentials">
+    Fill in a connection name, the OAuth **client ID** and **client secret**,
+    and the device tag(s) sessions should advertise (for example
+    `tag:tembo-session`).
+
+    Tembo validates the credentials against the Tailscale API before saving
+    — if the client ID or secret is wrong, you'll see an error immediately.
+  </Step>
+</Steps>
+
+Installing the integration also creates a managed **`/tailscale`** skill for
+your organization. This skill teaches agents how to join the tailnet and how
+to reach hosts through it; you don't need to configure anything else.
+
+## Usage
+
+Ask an agent to do something that requires your private network, and mention
+the tailnet or Tailscale if you want to be explicit:
+
+- "Use tailscale to query the staging database and summarize yesterday's failed jobs."
+- "SSH into the metrics host on our tailnet and check disk usage."
+- "Hit the internal admin API and pull the feature-flag config."
+
+The agent invokes the `/tailscale` skill, requests a one-time key from the
+Tembo API, joins your tailnet as `tembo-session-<session-id>`, and does the
+work. Sessions appear in your Tailscale admin console as tagged devices
+while active and remove themselves when the session ends.
+
+## Advanced
+
+<AccordionGroup>
+  <Accordion title="Security model">
+    - Your OAuth client credentials are stored encrypted with the integration
+      and used only server-side by the Tembo API. They are never sent to a
+      sandbox.
+    - When a session joins, the Tembo API mints a **single-use, ephemeral,
+      pre-authorized** auth key restricted to your configured tags, with an
+      expiry of minutes. That key is the only credential the sandbox ever
+      sees.
+    - Sessions are outbound-only participants on your tailnet. Nothing on
+      your tailnet needs to (or should) connect into a session.
+    - Removing the integration deletes the managed skill; you can also revoke
+      the OAuth client in Tailscale at any time to cut off all key minting.
+  </Accordion>
+
+  <Accordion title="How sessions connect">
+    Sandboxes run `tailscaled` in userspace networking mode (no root, no TUN
+    device). Traffic to your tailnet flows through Tailscale's encrypted
+    WireGuard tunnel, typically relayed over HTTPS (DERP) since sandboxes
+    don't accept inbound UDP. Agents reach your hosts via Tailscale SSH, a
+    local SOCKS5/HTTP proxy, or TCP tunneling — the managed skill covers all
+    of this so agents handle it automatically.
+  </Accordion>
+
+  <Accordion title="Multiple tags or tailnets">
+    You can list multiple tags when installing (all must be owned by the
+    OAuth client). The integration connects to the OAuth client's tailnet;
+    to serve multiple tailnets, install the integration once per tailnet.
+  </Accordion>
+
+  <Accordion title="Troubleshooting">
+    - **Install fails with "Invalid Tailscale credentials"** — the client ID
+      or secret is wrong, or the OAuth client lacks the auth-keys write
+      scope.
+    - **Agent reports `requested tags are invalid or not permitted`** — the
+      tag you configured in Tembo isn't assigned to the OAuth client in
+      Tailscale (check both `tagOwners` and the client's tag assignment).
+    - **Agent reports connections to a host time out** — your ACL policy
+      doesn't allow `tag:tembo-session` to reach that host and port. This is
+      Tailscale working as intended; extend your ACLs if the access is
+      wanted.
+    - **A skill named `tailscale` already exists** — the integration installs
+      a managed `/tailscale` skill and won't overwrite a skill you authored
+      with the same name. Rename or delete yours and install again.
+  </Accordion>
+</AccordionGroup>

--- a/integrations/tailscale.mdx
+++ b/integrations/tailscale.mdx
@@ -83,10 +83,11 @@ You need admin access to your Tailscale organization to complete the setup:
   </Step>
   <Step title="Create an OAuth client">
     In [**Settings → Trust credentials**](https://console.tailscale.com/admin/settings/trust-credentials),
-    click **+ Credential**, select **OAuth**, and continue. Give the client
-    the **Keys → Auth keys** write scope, and assign it the tag you created
-    (`tag:tembo-session`). Tembo uses this client to mint short-lived auth
-    keys — it can only create keys for the tags it owns.
+    click **+ Credential**, select **OAuth**, and continue. Under **Keys →
+    Auth keys**, select the **Write** scope — read access is not enough,
+    because Tembo has to create keys. Then assign the client the tag you
+    created (`tag:tembo-session`). Tembo uses this client to mint short-lived
+    auth keys — it can only create keys for the tags it owns.
 
     Copy the **client ID** and **client secret**; you'll enter them in Tembo
     next.
@@ -165,8 +166,8 @@ while active and remove themselves when the session ends.
 
   <Accordion title="Troubleshooting">
     - **Install fails with "Invalid Tailscale credentials"** — the client ID
-      or secret is wrong, or the OAuth client lacks the auth-keys write
-      scope.
+      or secret is wrong, or the OAuth client lacks the **Keys → Auth keys**
+      **Write** scope.
     - **Agent reports `requested tags are invalid or not permitted`** — the
       tag you configured in Tembo isn't assigned to the OAuth client in
       Tailscale (check both `tagOwners` and the client's tag assignment).

--- a/integrations/tailscale.mdx
+++ b/integrations/tailscale.mdx
@@ -82,8 +82,9 @@ You need admin access to your Tailscale organization to complete the setup:
     ```
   </Step>
   <Step title="Create an OAuth client">
-    In **Settings → OAuth clients**, create a client with the **Keys → Auth
-    keys** write scope, and assign it the tag you created
+    In [**Settings → Trust credentials**](https://console.tailscale.com/admin/settings/trust-credentials),
+    click **+ Credential**, select **OAuth**, and continue. Give the client
+    the **Keys → Auth keys** write scope, and assign it the tag you created
     (`tag:tembo-session`). Tembo uses this client to mint short-lived auth
     keys — it can only create keys for the tags it owns.
 


### PR DESCRIPTION
## Summary

Documents the new Tailscale integration (tembo/monorepo#9895): connecting Tembo sandbox sessions to a customer's private network (tailnet) with on-demand, single-use ephemeral auth keys.

## What's included

- **`integrations/tailscale.mdx`** — full integration guide:
  - Overview of the security model (opt-in per task, single-use ephemeral keys, customer ACLs govern all access, unprivileged userspace networking)
  - Prerequisites: choosing a device tag, `tagOwners` + `acls` + `ssh` policy examples for the Tailscale admin console, creating a scoped OAuth client
  - Installation steps in the Tembo app (Settings → Integrations → Developer Tools)
  - Usage examples and how the managed `/tailscale` skill works
  - Advanced accordions: security model detail, connection mechanics (userspace/DERP), multi-tag/tailnet setups, troubleshooting (credential validation, tag-permission errors, ACL timeouts, skill name conflicts)
- **`docs.json`** — registered `integrations/tailscale` in the Integrations nav group
- **`integrations.mdx`** — added a Tailscale card under Data and infrastructure

## Notes

- Marked as **preview** with a note to contact support, matching the `is-internal` feature-flag gating in the app.
- All ACL/OAuth setup snippets follow Tailscale's policy-file syntax and mirror the flow verified end-to-end while building the integration. 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/da2f5ac8-61cd-48a3-bd00-a9dd664ddb8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a> <a href="https://app.tembo.io/reviews/redirect?sessionId=da2f5ac8-61cd-48a3-bd00-a9dd664ddb8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=1"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=1"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=1" width="165" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-fable-5:high?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-fable-5:high?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-fable-5:high?theme=light&v=12" height="28"></picture></a> 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code, auth, or data-handling impact.
> 
> **Overview**
> **Adds documentation for the Tailscale integration** so customers can connect Tembo sandbox sessions to a private tailnet using on-demand, single-use ephemeral auth keys.
> 
> New **`integrations/tailscale.mdx`** covers the security model (opt-in per task, ephemeral keys, ACL-scoped access, userspace networking), Tailscale admin setup (tags, ACL/SSH examples, OAuth client with auth-key write scope), Tembo install steps, usage via the managed **`/tailscale`** skill, and advanced troubleshooting. The page is marked **preview** with a note to contact support.
> 
> **`docs.json`** registers **`integrations/tailscale`** in the Integrations nav. **`integrations.mdx`** adds a Tailscale card under Data and infrastructure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e7aaea15fd3d3ed574f93b6f1ae2af68250520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->