### PR TITLE
chore(github): add docs code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS — path-scoped ownership for the docs.
+#
+# Rules: the LAST matching pattern wins, so keep the catch-all fallback at the
+# top and more specific paths below it. Owners must have write access to the
+# repo (teams must also be visible). Check for silently-ignored entries under
+# Repository -> Insights -> Code owners errors.
+
+# Fallback — last-resort owners for anything not matched below
+*                       @tembo/engineers
+
+# Sensitive: CI/CD
+/.github/workflows/     @DarrenBaldwin07 @milldr @coleary005
+
+# Changes to ownership itself get reviewed by leads
+/.github/CODEOWNERS     @DarrenBaldwin07 @milldr

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,11 +5,21 @@
 # repo (teams must also be visible). Check for silently-ignored entries under
 # Repository -> Insights -> Code owners errors.
 
-# Fallback — last-resort owners for anything not matched below
-*                       @tembo/engineers
+# Fallback — active maintainers with repository-wide context
+*                       @DarrenBaldwin07 @benja @ryw
 
-# Sensitive: CI/CD
-/.github/workflows/     @DarrenBaldwin07 @milldr @coleary005
+# Documentation areas
+/api/                   @DarrenBaldwin07 @benja
+/features/              @Coleary005 @DarrenBaldwin07 @benja
+/integrations/          @benja @DarrenBaldwin07
+/learn/                 @benja @DarrenBaldwin07
+/models/                @DarrenBaldwin07
+/resources/             @DarrenBaldwin07 @cooper-gadd
+/docs.json              @benja @DarrenBaldwin07 @Coleary005
+/openapi*.yml           @DarrenBaldwin07 @benja @vrmiguel
 
-# Changes to ownership itself get reviewed by leads
-/.github/CODEOWNERS     @DarrenBaldwin07 @milldr
+# Sensitive: CI/CD and repository automation
+/.github/workflows/     @Coleary005 @milldr @DarrenBaldwin07
+
+# Changes to ownership itself get reviewed by repository maintainers
+/.github/CODEOWNERS     @DarrenBaldwin07 @benja @ryw


### PR DESCRIPTION
## Summary

- add path-scoped CODEOWNERS for active documentation maintainers
- assign API, features, integrations, learning, navigation, OpenAPI, and CI ownership
- require repository maintainers to review ownership changes

## Validation

- confirmed every listed owner has write or admin access
- merged current origin/main with no conflicts
- verified the CODEOWNERS diff with git diff --check 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/d4b202d1-2d2c-4dab-9f25-29afb3a2b811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a> <a href="https://app.tembo.io/reviews/redirect?sessionId=d4b202d1-2d2c-4dab-9f25-29afb3a2b811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=1"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=1"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=1" width="165" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol?theme=light&v=12" height="28"></picture></a> 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository automation only; no application or runtime behavior changes.
> 
> **Overview**
> Introduces **`.github/CODEOWNERS`** so GitHub can auto-request reviews from the right maintainers on docs changes.
> 
> A repo-wide fallback (`*`) covers general edits; **more specific paths override it** (last match wins), including `/api/`, `/features/`, `/integrations/`, `/learn/`, `/models/`, `/resources/`, `docs.json`, and `openapi*.yml`. **CI workflow changes** under `/.github/workflows/` get a dedicated owner set, and **edits to CODEOWNERS itself** require review from repository maintainers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e4f36c34a64abe45583e256b88f6041c3900122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->