### PR TITLE
docs(pricing): add XXL and Ultra VM sizes

### DIFF
--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -46,6 +46,8 @@ The per-size hourly prices below apply those resource rates to each VM configura
 | Medium | 4 | 8 GiB | $0.2652 |
 | Large | 8 | 16 GiB | $0.5304 |
 | XL | 16 | 32 GiB | $1.0608 |
+| XXL | 16 | 64 GiB | $1.4768 |
+| Ultra | 32 | 128 GiB | $2.9536 |
 
 Tembo measures each running VM in seconds and bills its actual running time at the per-second equivalent of the hourly rate. Stopped, snapshotted, and otherwise non-running VMs do not accrue compute.
 


### PR DESCRIPTION
## summary

- add XXL (16 vCPU, 64 GiB) to the cloud VM pricing table
- add Ultra (32 vCPU, 128 GiB) to the cloud VM pricing table
- calculate hourly prices from the documented compute rates

## validation

- verified hourly price calculations against `$0.0403/vCPU-hour + $0.0130/GiB-RAM-hour`
- ran `git diff --check`
- merged the latest `origin/main` before committing; no conflicts
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/44b01672-aa90-4a7f-aa31-398a21c64f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a> <a href="https://app.tembo.io/reviews/redirect?sessionId=44b01672-aa90-4a7f-aa31-398a21c64f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=2"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=2" width="165" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol?theme=light&v=12" height="28"></picture></a> <a href="https://tembo-io.slack.com/archives/C094UFXHKKP/p1785461684702479?thread_ts=1785461314.073139&cid=C094UFXHKKP"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>