### PR TITLE
docs(api): use public API endpoint prefix

### DIFF
--- a/api/index.mdx
+++ b/api/index.mdx
@@ -13,7 +13,7 @@ Generate an API key from **Settings > API Keys** in the [dashboard](https://app.
 
 ```bash
 curl -H "Authorization: Bearer YOUR_API_KEY" \
-  https://api.tembo.io/session/list
+  https://api.tembo.io/public-api/session/list
 ```
 
 ## SDK

--- a/integrations/snowflake.mdx
+++ b/integrations/snowflake.mdx
@@ -36,7 +36,7 @@ The integration is implemented as a Snowflake-managed MCP server that exposes Te
   - `CREATE AGENT` on the target schema
   - `USAGE` on a warehouse the agent will run with
 - A Tembo API token — generate one from your Tembo account settings
-- The Tembo REST API base URL: `https://api.tembo.io`
+- The Tembo REST API base URL: `https://api.tembo.io/public-api`
 
 For self-hosted Tembo installs, substitute your deployment's base URL throughout. See [Self-Hosted Overview](/features/self-hosted/overview) for details.
 
@@ -96,7 +96,7 @@ PACKAGES = ('requests')
 AS $$
 import _snowflake, json, requests
 
-BASE = "https://api.tembo.io"
+BASE = "https://api.tembo.io/public-api"
 
 ROUTES = {
     "list_sessions":      ("GET",  "/session/list"),
@@ -333,7 +333,7 @@ SHOW EXTERNAL ACCESS INTEGRATIONS LIKE 'tembo_api_access_integration';
   </Accordion>
 
   <Accordion title="Self-hosted Tembo">
-    For self-hosted Tembo, replace `https://api.tembo.io` with your deployment's base URL in both the network rule (`VALUE_LIST`) and the Python UDF (`BASE`). The rest of the flow is identical.
+    For self-hosted Tembo, replace `https://api.tembo.io/public-api` with your deployment's public API base URL (for example, `https://tembo.example.com/api/public-api`) in the Python UDF (`BASE`). Update the network rule (`VALUE_LIST`) to allow your deployment's host. The rest of the flow is identical.
   </Accordion>
 
   <Accordion title="Rotating the API token">

--- a/openapi.documented.yml
+++ b/openapi.documented.yml
@@ -4,7 +4,7 @@ info:
     description: Tembo Developer API
     version: 1.0.0
 servers:
-    - url: https://api.tembo.io/
+    - url: https://api.tembo.io/public-api/
       description: Tembo API
 components:
     securitySchemes:
@@ -552,7 +552,7 @@ paths:
                   label: cURL
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/session/${SESSION_ID}/messages" \
+                        "https://api.tembo.io/public-api/session/${SESSION_ID}/messages" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"content": "Please add a regression test for this change."}'
@@ -702,7 +702,7 @@ paths:
                 - lang: bash
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/agent" \
+                        "https://api.tembo.io/public-api/agent" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{
@@ -812,7 +812,7 @@ paths:
                   label: Bearer Auth
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/agent/${AGENT_ID}/trigger" \
+                        "https://api.tembo.io/public-api/agent/${AGENT_ID}/trigger" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"issue_url": "https://github.com/org/repo/issues/42"}' | jq .
@@ -820,7 +820,7 @@ paths:
                   label: Query Param Auth
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/agent/${AGENT_ID}/trigger?apiKey=${API_KEY}" \
+                        "https://api.tembo.io/public-api/agent/${AGENT_ID}/trigger?apiKey=${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"issue_url": "https://github.com/org/repo/issues/42"}' | jq .
     /repository/list:

--- a/openapi.self-hosted.yml
+++ b/openapi.self-hosted.yml
@@ -552,7 +552,7 @@ paths:
                   label: cURL
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/session/${SESSION_ID}/messages" \
+                        "https://tembo.example.com/api/public-api/session/${SESSION_ID}/messages" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"content": "Please add a regression test for this change."}'


### PR DESCRIPTION
## summary

- point the hosted openapi reference at `https://api.tembo.io/public-api/`
- update explicit hosted api examples and the snowflake integration base url
- fix the remaining hosted url in the self-hosted openapi example

## validation

- `mintlify validate`
- `git diff --check`
- audited public api routes against `monorepo/apps/api/src/server/routes/public-api`
- merged `origin/main` before committing (already up to date, no conflicts)
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/19a66bd7-5e53-4468-8012-1e941de11280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=19a66bd7-5e53-4468-8012-1e941de11280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12" height="28"></picture></a>&nbsp;&nbsp;<a href="https://tembo-io.slack.com/archives/C09ELSP1RBQ/p1786061022785639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL corrections with no runtime or API behavior changes.
> 
> **Overview**
> Documentation now points integrators and API consumers at the **`/public-api`** path on the hosted Tembo API instead of the bare `api.tembo.io` host root.
> 
> **API overview** (`api/index.mdx`) updates the sample `curl` to `https://api.tembo.io/public-api/session/list`. **OpenAPI** (`openapi.documented.yml`) changes the server URL to `https://api.tembo.io/public-api/` and refreshes cURL samples for session messages, agent create, and agent trigger. **Snowflake** (`integrations/snowflake.mdx`) sets the documented base URL and Python UDF `BASE` to `https://api.tembo.io/public-api`, and clarifies self-hosted substitution (e.g. `https://tembo.example.com/api/public-api`). **Self-hosted OpenAPI** (`openapi.self-hosted.yml`) fixes one remaining hosted URL in a cURL example to `https://tembo.example.com/api/public-api/...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6455de21a45f5ab4663e4d2d96f76365f92d7a4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->