### PR TITLE
docs: show compute pricing before gateway pricing

### DIFF
--- a/resources/pricing.mdx
+++ b/resources/pricing.mdx
@@ -26,6 +26,35 @@ BYOK and ChatGPT/Codex OAuth inference cost \$0 through Tembo because you provid
 
 Included monthly allowance expires at the end of each billing cycle and does not roll over. Prepaid balance does not expire.
 
+## Cloud VM compute rates
+
+VM compute is a separate usage category from Tembo Gateway. It draws from the same dollar-denominated allowance at **\$0.0403/vCPU-hour + \$0.0130/GiB-RAM-hour**.
+
+| Resource | Rate |
+| --- | ---: |
+| vCPU | $0.0403 per vCPU-hour |
+| Memory | $0.0130 per GiB RAM-hour |
+
+The per-size hourly prices below apply those resource rates to each VM configuration.
+
+| Size | vCPU | Memory | Price per hour |
+| --- | ---: | ---: | --- |
+| Nano | 2 | 2 GiB | $0.1066 |
+| Micro | 2 | 4 GiB | $0.1326 |
+| Medium | 4 | 8 GiB | $0.2652 |
+| Large | 8 | 16 GiB | $0.5304 |
+| XL | 16 | 32 GiB | $1.0608 |
+| XXL | 16 | 64 GiB | $1.4768 |
+| Ultra | 32 | 128 GiB | $2.9536 |
+
+<Note>
+  **Don't see the VM size you want?** Larger VM sizes are available upon request. Contact [support@tembo.io](mailto:support@tembo.io) to discuss your requirements.
+</Note>
+
+Tembo measures each running VM in seconds and bills its actual running time at the per-second equivalent of the hourly rate. Stopped, snapshotted, and otherwise non-running VMs do not accrue compute.
+
+See [Sandboxes](/features/sandbox/overview) for more about the execution environment.
+
 ## Tembo Gateway pricing
 
 Pricing is shown in USD per 1M tokens.
@@ -56,35 +85,6 @@ Pricing is shown in USD per 1M tokens.
 | Tembo | `deepseek-v4-pro` | $2.001 | $4.002 | n/a | $0.16675 |
 | Tembo | `deepseek-v4-flash` | $0.161 | $0.322 | n/a | $0.0345 |
 | Tembo | `nvidia-nemotron-3-ultra-nvfp4` | $0.69 | $2.76 | n/a | $0.138 |
-
-## Cloud VM compute rates
-
-VM compute is a separate usage category from Tembo Gateway. It draws from the same dollar-denominated allowance at **\$0.0403/vCPU-hour + \$0.0130/GiB-RAM-hour**.
-
-| Resource | Rate |
-| --- | ---: |
-| vCPU | $0.0403 per vCPU-hour |
-| Memory | $0.0130 per GiB RAM-hour |
-
-The per-size hourly prices below apply those resource rates to each VM configuration.
-
-| Size | vCPU | Memory | Price per hour |
-| --- | ---: | ---: | --- |
-| Nano | 2 | 2 GiB | $0.1066 |
-| Micro | 2 | 4 GiB | $0.1326 |
-| Medium | 4 | 8 GiB | $0.2652 |
-| Large | 8 | 16 GiB | $0.5304 |
-| XL | 16 | 32 GiB | $1.0608 |
-| XXL | 16 | 64 GiB | $1.4768 |
-| Ultra | 32 | 128 GiB | $2.9536 |
-
-<Note>
-  **Don't see the VM size you want?** Larger VM sizes are available upon request. Contact [support@tembo.io](mailto:support@tembo.io) to discuss your requirements.
-</Note>
-
-Tembo measures each running VM in seconds and bills its actual running time at the per-second equivalent of the hourly rate. Stopped, snapshotted, and otherwise non-running VMs do not accrue compute.
-
-See [Sandboxes](/features/sandbox/overview) for more about the execution environment.
 
 ## What consumes the allowance
 


### PR DESCRIPTION
## Summary

- move cloud vm compute rates ahead of tembo gateway pricing
- preserve the existing pricing content and section anchors

## Validation

- `npx --yes mintlify@latest validate`
- `git diff --check`
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/402e06ec-680c-4a40-be76-36de438964a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=402e06ec-680c-4a40-be76-36de438964a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:xhigh?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:xhigh?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:xhigh?theme=light&v=12" height="28"></picture></a>&nbsp;&nbsp;<a href="https://tembo-io.slack.com/archives/C094UFXHKKP/p1786457791047149?thread_ts=1786457589.489979&cid=C094UFXHKKP"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>