### PR TITLE
docs(gitlab): document service account tokens

### DIFF
--- a/integrations/gitlab.mdx
+++ b/integrations/gitlab.mdx
@@ -16,17 +16,41 @@ description: 'Merge requests, code scanning, and pipeline monitoring.'
 
 ## Installation
 
+Tembo supports a shared GitLab service account or a personal account connected through OAuth. We recommend a service account so the integration does not depend on an individual team member.
+
+### Connect a service account
+
+You must be a Tembo organization admin. On GitLab.com, you must also be an Owner of the top-level group and may need to verify your identity. For GitLab Self-Managed or Dedicated, you must be an instance administrator or an Owner who is allowed to create service accounts.
+
 <Steps>
-  <Step title="Install">
-    Go to [Integrations](https://app.tembo.io/integrations) and click **Install** next to GitLab.
+  <Step title="Create a GitLab service account">
+    In GitLab, open your top-level group and go to **Settings → Service accounts**. Select **Add service account**, name the account, and select **Create service account**.
+
+    See [GitLab's service account instructions](https://docs.gitlab.com/user/profile/service_accounts/#create-a-service-account) for GitLab.com and self-managed prerequisites.
   </Step>
-  <Step title="Authorize">
-    We recommend creating a dedicated GitLab account for Tembo. Authorize access and select repositories.
+  <Step title="Grant repository access">
+    Add the service account as a member of the top-level group or each project that Tembo should access. Assign the **Maintainer** role so Tembo can create project webhooks as well as branches and merge requests. GitLab requires the Maintainer or Owner role to [create project webhooks](https://docs.gitlab.com/user/project/integrations/webhooks/#create-a-webhook).
   </Step>
-  <Step title="Activate">
-    Select which repositories Tembo should work with under "Active Repositories".
+  <Step title="Create an access token">
+    On **Settings → Service accounts**, open the service account's menu and select **Manage access tokens → Add new token**. Enter a name and expiration date, select only the `api` scope, and select **Create personal access token**. Copy the generated token.
+
+    GitLab documents token creation, expiration limits, rotation, and revocation under [Create a personal access token for a service account](https://docs.gitlab.com/user/profile/service_accounts/#create-a-personal-access-token-for-a-service-account).
+  </Step>
+  <Step title="Connect Tembo">
+    In Tembo, go to [Integrations](https://app.tembo.io/integrations) and select **Install** next to GitLab. Paste the token into **Service account access token**, then select **Connect with access token**.
+  </Step>
+  <Step title="Activate repositories">
+    Select which repositories Tembo should work with under **Active Repositories**.
   </Step>
 </Steps>
+
+<Note>
+  Tembo rejects tokens owned by regular personal user accounts. When the service account token expires, is rotated, or is revoked, reconnect the integration with the new token.
+</Note>
+
+### Connect with OAuth
+
+Go to [Integrations](https://app.tembo.io/integrations), select **Install** next to GitLab, and select **Continue with OAuth**. Authorize access, then select which repositories Tembo should work with under **Active Repositories**.
 
 ## Usage
 


### PR DESCRIPTION
## summary

- recommend gitlab service accounts for organization-owned access
- document service account creation, membership, token scope, and tembo setup
- retain oauth as an alternative and explain token rotation behavior

## implementation notes

- tembo accepts bot-owned gitlab tokens with the `api` scope and rejects regular personal-user tokens
- maintainer access is recommended because tembo registers project webhooks during sync
- instructions follow gitlab's current service account and webhook documentation

## validation

- `npx --yes mintlify@latest validate`
- verified the linked gitlab documentation pages return 200
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/e524e360-447b-495d-8154-e1990b5837d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=e524e360-447b-495d-8154-e1990b5837d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:high?theme=light&v=12" height="28"></picture></a>&nbsp;&nbsp;<a href="https://tembo-io.slack.com/archives/C09ELSP1RBQ/p1786492627998369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to GitLab setup instructions with no code, auth, or runtime behavior changes.
> 
> **Overview**
> Rewrites GitLab installation docs to **recommend a shared service account** instead of a personal OAuth login, so the integration is not tied to one team member.
> 
> Adds step-by-step guidance for creating the service account, granting **Maintainer** access, minting an `api`-scoped token, and connecting it in Tembo. Keeps OAuth as a shorter alternative path and notes that personal-user tokens are rejected and expired/rotated tokens need reconnecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f39c09cdc38b4fe2c659980f0bc9634e78c5cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->