### PR TITLE
Document custom inference for self-hosted deployments

### DIFF
--- a/features/self-hosted/overview.mdx
+++ b/features/self-hosted/overview.mdx
@@ -66,6 +66,12 @@ Self-hosted is designed for teams that want Tembo inside a private cloud, dedica
 - Outbound access can be limited to the systems Tembo needs to reach, such as git providers, model endpoints, or internal services
 - Upgrades happen on your schedule
 
+## Custom inference
+
+You can route model requests through your own inference service by replacing the default Anthropic and OpenAI base URLs with endpoints you control. These endpoints can be internal gateways, proxies, or self-hosted model services, as long as they implement the corresponding Anthropic or OpenAI API.
+
+Make sure the Tembo instance and its agent sandboxes can reach the custom endpoints and that the endpoints expose the model names configured in Tembo.
+
 ## Who it is for
 
 - Teams that need Tembo inside infrastructure they control


### PR DESCRIPTION
## Summary

- Explain that self-hosted operators can replace the default Anthropic and OpenAI base URLs with endpoints they control.
- Document API compatibility, model naming, and network reachability requirements for custom inference.

## Validation

- Mintlify strict build validation 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/18e946b2-2d26-453b-b5ff-d17e2ce615b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=18e946b2-2d26-453b-b5ff-d17e2ce615b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:xhigh?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:xhigh?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:xhigh?theme=light&v=12" height="28"></picture></a>&nbsp;&nbsp;<a href="https://tembo-io.slack.com/archives/C08S9PXF1KJ/p1787058395573769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=dark&v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2"><img alt="View on slack" src="https://internal.tembo.io/public/vendor-button/slack?theme=light&v=2" height="28"></picture></a>