### PR TITLE
docs(api): document canonical v1 routes

### DIFF
--- a/api/index.mdx
+++ b/api/index.mdx
@@ -13,7 +13,7 @@ Generate an API key from **Settings > API Keys** in the [dashboard](https://app.
 
 ```bash
 curl -H "Authorization: Bearer YOUR_API_KEY" \
-  https://api.tembo.io/session/list
+  https://api.tembo.io/v1/session/list
 ```
 
 ## SDK

--- a/api/self-hosted/index.mdx
+++ b/api/self-hosted/index.mdx
@@ -11,7 +11,7 @@ Replace `tembo.example.com` with the hostname of your Tembo instance.
 
 ```bash
 curl -H "Authorization: Bearer YOUR_API_KEY" \
-  https://tembo.example.com/api/public-api/session/list
+  https://tembo.example.com/api/public-api/v1/session/list
 ```
 
 ## SDK
@@ -39,7 +39,7 @@ import Tembo from '@tembo-io/sdk';
 
 const client = new Tembo({
   apiKey: process.env.TEMBO_API_KEY,
-  baseURL: 'https://tembo.example.com/api/public-api/',
+  baseURL: 'https://tembo.example.com/api/public-api/v1/',
 });
 
 const session = await client.session.create({

--- a/integrations/snowflake.mdx
+++ b/integrations/snowflake.mdx
@@ -36,7 +36,7 @@ The integration is implemented as a Snowflake-managed MCP server that exposes Te
   - `CREATE AGENT` on the target schema
   - `USAGE` on a warehouse the agent will run with
 - A Tembo API token — generate one from your Tembo account settings
-- The Tembo REST API base URL: `https://api.tembo.io`
+- The Tembo REST API base URL: `https://api.tembo.io/v1`
 
 For self-hosted Tembo installs, substitute your deployment's base URL throughout. See [Self-Hosted Overview](/features/self-hosted/overview) for details.
 
@@ -96,7 +96,7 @@ PACKAGES = ('requests')
 AS $$
 import _snowflake, json, requests
 
-BASE = "https://api.tembo.io"
+BASE = "https://api.tembo.io/v1"
 
 ROUTES = {
     "list_sessions":      ("GET",  "/session/list"),
@@ -308,7 +308,7 @@ SHOW EXTERNAL ACCESS INTEGRATIONS LIKE 'tembo_api_access_integration';
     ```sql
     CREATE OR REPLACE API INTEGRATION tembo_mcp_api_integration
       API_PROVIDER = external_mcp
-      API_ALLOWED_PREFIXES = ('https://api.tembo.io/public-api/mcp')
+      API_ALLOWED_PREFIXES = ('https://api.tembo.io/v1/mcp')
       API_USER_AUTHENTICATION = (
         TYPE = OAUTH2
         OAUTH_CLIENT_ID = '<client_id>'
@@ -333,7 +333,7 @@ SHOW EXTERNAL ACCESS INTEGRATIONS LIKE 'tembo_api_access_integration';
   </Accordion>
 
   <Accordion title="Self-hosted Tembo">
-    For self-hosted Tembo, replace `https://api.tembo.io` with your deployment's base URL in both the network rule (`VALUE_LIST`) and the Python UDF (`BASE`). The rest of the flow is identical.
+    For self-hosted Tembo, replace `api.tembo.io:443` in the network rule with your deployment's host and set the Python UDF's `BASE` to `https://your-host.example.com/api/public-api/v1`. The rest of the flow is identical.
   </Accordion>
 
   <Accordion title="Rotating the API token">

--- a/openapi.documented.yml
+++ b/openapi.documented.yml
@@ -4,7 +4,7 @@ info:
     description: Tembo Developer API
     version: 1.0.0
 servers:
-    - url: https://api.tembo.io/
+    - url: https://api.tembo.io/v1/
       description: Tembo API
 components:
     securitySchemes:
@@ -552,7 +552,7 @@ paths:
                   label: cURL
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/session/${SESSION_ID}/messages" \
+                        "https://api.tembo.io/v1/session/${SESSION_ID}/messages" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"content": "Please add a regression test for this change."}'
@@ -621,7 +621,7 @@ paths:
                   label: cURL
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/session/${SESSION_ID}/stop" \
+                        "https://api.tembo.io/v1/session/${SESSION_ID}/stop" \
                         -H "Authorization: Bearer ${API_KEY}"
 
     /agent:
@@ -769,7 +769,7 @@ paths:
                 - lang: bash
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/agent" \
+                        "https://api.tembo.io/v1/agent" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{
@@ -879,7 +879,7 @@ paths:
                   label: Bearer Auth
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/agent/${AGENT_ID}/trigger" \
+                        "https://api.tembo.io/v1/agent/${AGENT_ID}/trigger" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"issue_url": "https://github.com/org/repo/issues/42"}' | jq .
@@ -887,7 +887,7 @@ paths:
                   label: Query Param Auth
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/agent/${AGENT_ID}/trigger?apiKey=${API_KEY}" \
+                        "https://api.tembo.io/v1/agent/${AGENT_ID}/trigger?apiKey=${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"issue_url": "https://github.com/org/repo/issues/42"}' | jq .
     /repository/list:

--- a/openapi.self-hosted.yml
+++ b/openapi.self-hosted.yml
@@ -4,7 +4,7 @@ info:
     description: Tembo Self-Hosted Developer API
     version: 1.0.0
 servers:
-    - url: https://tembo.example.com/api/public-api/
+    - url: https://tembo.example.com/api/public-api/v1/
       description: Tembo self-hosted API
 components:
     securitySchemes:
@@ -552,7 +552,7 @@ paths:
                   label: cURL
                   source: |-
                       curl -s -X POST \
-                        "https://api.tembo.io/session/${SESSION_ID}/messages" \
+                        "https://tembo.example.com/api/public-api/v1/session/${SESSION_ID}/messages" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"content": "Please add a regression test for this change."}'
@@ -621,7 +621,7 @@ paths:
                   label: cURL
                   source: |-
                       curl -s -X POST \
-                        "https://tembo.example.com/api/public-api/session/${SESSION_ID}/stop" \
+                        "https://tembo.example.com/api/public-api/v1/session/${SESSION_ID}/stop" \
                         -H "Authorization: Bearer ${API_KEY}"
 
     /agent:
@@ -769,7 +769,7 @@ paths:
                 - lang: bash
                   source: |-
                       curl -s -X POST \
-                        "https://tembo.example.com/api/public-api/agent" \
+                        "https://tembo.example.com/api/public-api/v1/agent" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{
@@ -879,7 +879,7 @@ paths:
                   label: Bearer Auth
                   source: |-
                       curl -s -X POST \
-                        "https://tembo.example.com/api/public-api/agent/${AGENT_ID}/trigger" \
+                        "https://tembo.example.com/api/public-api/v1/agent/${AGENT_ID}/trigger" \
                         -H "Authorization: Bearer ${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"issue_url": "https://github.com/org/repo/issues/42"}' | jq .
@@ -887,7 +887,7 @@ paths:
                   label: Query Param Auth
                   source: |-
                       curl -s -X POST \
-                        "https://tembo.example.com/api/public-api/agent/${AGENT_ID}/trigger?apiKey=${API_KEY}" \
+                        "https://tembo.example.com/api/public-api/v1/agent/${AGENT_ID}/trigger?apiKey=${API_KEY}" \
                         -H "Content-Type: application/json" \
                         -d '{"issue_url": "https://github.com/org/repo/issues/42"}' | jq .
     /repository/list:


### PR DESCRIPTION
## Summary

- advertise `https://api.tembo.io/v1/` as the canonical hosted API base
- advertise `/api/public-api/v1/` as the canonical self-hosted API base
- update curl, SDK, OpenAPI, and Snowflake examples to use the versioned routes
- correct the self-hosted follow-up-message sample so it uses the self-hosted host

## Validation

- parsed both OpenAPI YAML files successfully
- confirmed hosted and self-hosted specs expose matching operation paths
- scanned the API docs for stale versionless public endpoint URLs
- ran `git diff --check`

## Rollout

This documentation should merge after the API `/v1` routing change is deployed. Hosted versionless URLs remain backward-compatible, but `/v1` is the canonical documented contract.
 
  


 <br /> 


 > Want tembo to make any changes? Add a comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/sessions/9d716240-cefb-4f1b-984c-8a9e0a13b6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=3"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=3" width="134" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/reviews/redirect?sessionId=9d716240-cefb-4f1b-984c-8a9e0a13b6c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=dark&v=3"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3"><img alt="Review in Tembo" src="https://internal.tembo.io/public/tembo-button/review?theme=light&v=3" width="145" height="28"></picture></a>&nbsp;&nbsp;<a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:xhigh?theme=dark&v=12"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:xhigh?theme=light&v=12"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/codex:gpt-5.6-sol:xhigh?theme=light&v=12" height="28"></picture></a>